### PR TITLE
remove link to un-existing script

### DIFF
--- a/docs/usage/style.rst
+++ b/docs/usage/style.rst
@@ -28,16 +28,11 @@ Fonts
 
 Latin Modern fonts are used by default (Latin Modern Math, Latin Modern Roman, Latin Modern Sans).
 
-You can install the fonts by running on your terminal:
-
-On Linux/Ubuntu/MacOS
----------------------
+On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
 
 .. code-block:: bash
 
     install_latin_modern_fonts
-
-If the command above does not work, you can install the fonts by using the script located in the `github repository of plothist <https://github.com/cyrraz/plothist/tree/main/scripts/install_latin_modern_fonts.py>`_.
 
 
 Color palettes

--- a/docs/usage/style.rst
+++ b/docs/usage/style.rst
@@ -34,6 +34,7 @@ On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
 
     install_latin_modern_fonts
 
+If the command doesn't work, you can read the detailed instructions direclty in the python script `here <https://github.com/cyrraz/plothist/blob/main/plothist/scripts/install_latin_modern_fonts.py>`_.
 
 Color palettes
 ==============


### PR DESCRIPTION
Title.
We don't have the script anymore. If the command line doesn't work, the other alternative should be to download manually the fonts.