### PR TITLE
Option to have the right edge inclusive

### DIFF
--- a/plothist/plotters.py
+++ b/plothist/plotters.py
@@ -54,7 +54,7 @@ def create_comparison_figure(
     return fig, axes
 
 
-def create_axis(data, bins, range=None):
+def create_axis(data, bins, range=None, overflow=True):
     """
     Create an axis object for histogram binning based on the input data and parameters.
 
@@ -111,7 +111,7 @@ def create_axis(data, bins, range=None):
         x_min = x_min - 0.5
         x_max = x_max + 0.5
 
-    return bh.axis.Regular(bins, x_min, x_max)
+    return bh.axis.Regular(bins, x_min, x_max, overflow=overflow)
 
 
 def _flatten_2d_hist(hist):
@@ -137,7 +137,7 @@ def _flatten_2d_hist(hist):
     return flatten_hist
 
 
-def make_hist(data, bins=50, range=None, weights=1):
+def make_hist(data, bins=50, range=None, weights=1, overflow=True):
     """
     Create a histogram object and fill it with the provided data.
 
@@ -163,7 +163,7 @@ def make_hist(data, bins=50, range=None, weights=1):
         The filled histogram object.
     """
 
-    axis = create_axis(data, bins, range)
+    axis = create_axis(data, bins, range, overflow=overflow)
 
     if weights is None:
         storage = bh.storage.Double()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dynamic = ["version", "description"]
 requires-python = ">=3.7"
 dependencies = [
-    "boost-histogram~=1.3.1",
+    "boost-histogram~=1.4.0",
     "numpy>=1.14.5",
     "matplotlib>=3.0",
     "pyyaml>=5.3.1",


### PR DESCRIPTION
Proposition to add the option of including the right edge of the axis.

This behavior was implemented in `boost-histogram 1.4.0`: https://github.com/scikit-hep/boost-histogram/blob/c08b7efc34b4d9b07c7b6a71bd566fcf303c1d0f/docs/changelog.md?plain=1#L14

Useful when doing discrete variable representation, like a distribution following a bool 0 or 1. The trick we use currently is to set the upper edge to 1.001. With this PR, the upper edge can be 1, with the argument `overflow=False`.

This is not redundant with the implementation of a `axis.__Category`. `boost_histogram` only allows for `int` or `str` categories.