### PR TITLE
fix mc_uncertainty plot for function logic error

### DIFF
--- a/plothist/plotters.py
+++ b/plothist/plotters.py
@@ -944,6 +944,7 @@ def plot_model(
             model_uncertainty
             and len(stacked_components) == 0
             and len(unstacked_components) == 1
+            and model_type == "histograms"
         ):
             plot_hist_uncertainties(
                 sum(components), ax=ax, label=model_uncertainty_label


### PR DESCRIPTION
Before, if you only plot 1 function in `unstacked_component` of `plot_data_model_comparison`, the code wants to plot its unexisting `mc_uncertainty`. This PR fixes the bug.