### PR TITLE
Bugfix: correctly overwrite the range in registry if specified

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ plothist
    :target: https://badge.fury.io/py/plothist
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.0.2-blue.svg
+.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.0.3-blue.svg
    :target: https://plothist.readthedocs.io/en/latest/
 .. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg
    :target: https://plothist.readthedocs.io/en/main/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,9 +36,9 @@ copyright = "2023, Cyrille Praz, Tristan Fillinger"
 author = "Cyrille Praz, Tristan Fillinger"
 
 # The short X.Y version
-version = "1.0.2"
+version = "1.0.3"
 # The full version, including alpha/beta/rc tags
-release = "1.0.2"
+release = "1.0.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/plothist/__init__.py
+++ b/plothist/__init__.py
@@ -1,5 +1,5 @@
 """Plot histograms in a scalable way and a beautiful style."""
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from .plotters import (
     create_comparison_figure,

--- a/plothist/variable_registry.py
+++ b/plothist/variable_registry.py
@@ -281,10 +281,11 @@ def update_variable_registry_ranges(
             raise RuntimeError(
                 f"Variable {variable_key} does not have a bins or range property in the registry {path}."
             )
-        if variable["range"] == ["min", "max"] or overwrite:
-            if overwrite:
-                range = ["min", "max"]
-            axis = create_axis(data[variable_key], variable["bins"], variable["range"])
+
+        range = ["min", "max"] if overwrite else variable["range"]
+
+        if range == ["min", "max"]:
+            axis = create_axis(data[variable_key], variable["bins"], range)
             if isinstance(axis, bh.axis.Regular):
                 update_variable_registry(
                     {"range": [float(axis.edges[0]), float(axis.edges[-1])]},


### PR DESCRIPTION
Small bug, `overwrite=True` argument in `update_variable_registry_ranges()` was not working properly.