### PR TITLE
Add workflow for testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests with a variety of Python versions
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flit pytest
+        flit install
+    - name: Test with pytest
+      run: |
+        pytest

--- a/tests/test_histogramming.py
+++ b/tests/test_histogramming.py
@@ -1,0 +1,15 @@
+from plothist import make_hist
+import boost_histogram as bh
+
+
+def test_make_hist():
+    """
+    Test make_hist() function.
+    """
+    h = make_hist(data=[0, 1, 2, 3, 4], bins=5, range=(0, 5))
+    assert isinstance(h, bh.Histogram)
+    assert isinstance(h.axes[0], bh.axis.Regular)
+    assert h.sum().value == 5
+    assert h.sum().variance == 5
+    assert h[0].value == 1
+    assert h[-1].value == 1


### PR DESCRIPTION
This PR add a workflow for running pytest when a PR is opened against the main branch or when we push to the main branch.

This tests the code in all the python versions ranking from 3.7 to 3.11.

As you can see below, the simple implemented test is passed in the five versions of Python.