### PR TITLE
Time variable in italic in add_luminosity

### DIFF
--- a/docs/examples/1d_hist/1d_comparison_asymmetry.py
+++ b/docs/examples/1d_hist/1d_comparison_asymmetry.py
@@ -29,8 +29,8 @@ fig, ax_main, ax_comparison = plot_two_hist_comparison(
     h3,
     xlabel=name,
     ylabel="Entries",
-    h1_label="$h_2$",
-    h2_label="$h_3$",
+    h1_label="$\mathit{h}_2$",
+    h2_label="$\mathit{h}_3$",
     comparison="asymmetry",  # <--
 )
 

--- a/docs/img/1d_comparison_asymmetry.svg
+++ b/docs/img/1d_comparison_asymmetry.svg
@@ -888,64 +888,84 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_9">
-     <path d="M 346.82 26.4 
-L 370.82 26.4 
-L 370.82 18 
-L 346.82 18 
-L 346.82 26.4 
+     <path d="M 346.7 26.4 
+L 370.7 26.4 
+L 370.7 18 
+L 346.7 18 
+L 346.7 26.4 
 z
 " style="fill: none; stroke: #348abd; stroke-linejoin: miter"/>
     </g>
     <g id="text_7">
-     <!-- $h_2$ -->
-     <g style="fill: #1a1a1a" transform="translate(380.42 26.4) scale(0.12 -0.12)">
+     <!-- $\mathit{h}_2$ -->
+     <g style="fill: #1a1a1a" transform="translate(380.3 26.4) scale(0.12 -0.12)">
       <defs>
-       <path id="LatinModernMath-Regular-68" d="M 3424 0 
-L 3424 198 
-C 3091 198 2931 198 2925 390 
-L 2925 1613 
-C 2925 2163 2925 2362 2726 2592 
-C 2637 2701 2426 2829 2054 2829 
-C 1517 2829 1235 2445 1133 2214 
-L 1126 2214 
-L 1126 4442 
-L 205 4371 
-L 205 4173 
-C 653 4173 704 4128 704 3814 
-L 704 486 
-C 704 198 634 198 205 198 
-L 205 0 
-L 928 19 
-L 1645 0 
-L 1645 198 
-C 1216 198 1146 198 1146 486 
-L 1146 1664 
-C 1146 2330 1600 2688 2010 2688 
-C 2413 2688 2483 2342 2483 1978 
-L 2483 486 
-C 2483 198 2413 198 1984 198 
-L 1984 0 
-L 2707 19 
-L 3424 0 
+       <path id="Cmmi10-68" d="M 341 116 
+Q 341 153 347 172 
+L 1275 3872 
+Q 1300 3981 1306 4044 
+Q 1306 4147 891 4147 
+Q 825 4147 825 4231 
+Q 828 4247 839 4287 
+Q 850 4328 867 4350 
+Q 884 4372 916 4372 
+L 1778 4441 
+L 1797 4441 
+Q 1797 4434 1819 4423 
+Q 1841 4413 1844 4409 
+Q 1856 4378 1856 4359 
+L 1356 2363 
+Q 1750 2828 2291 2828 
+Q 2516 2828 2680 2750 
+Q 2844 2672 2936 2514 
+Q 3028 2356 3028 2138 
+Q 3028 1875 2911 1503 
+Q 2794 1131 2619 672 
+Q 2528 463 2528 288 
+Q 2528 97 2675 97 
+Q 2925 97 3092 364 
+Q 3259 631 3328 941 
+Q 3341 978 3378 978 
+L 3456 978 
+Q 3481 978 3497 961 
+Q 3513 944 3513 922 
+Q 3513 916 3506 903 
+Q 3450 672 3339 448 
+Q 3228 225 3059 76 
+Q 2891 -72 2663 -72 
+Q 2438 -72 2278 83 
+Q 2119 238 2119 459 
+Q 2119 578 2169 709 
+Q 2350 1191 2470 1569 
+Q 2591 1947 2591 2234 
+Q 2591 2419 2519 2541 
+Q 2447 2663 2278 2663 
+Q 1934 2663 1678 2452 
+Q 1422 2241 1234 1894 
+L 800 147 
+Q 775 50 703 -11 
+Q 631 -72 538 -72 
+Q 456 -72 398 -17 
+Q 341 38 341 116 
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(0 0.59375)"/>
-      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(56.354131 -12.334375) scale(0.7)"/>
+      <use xlink:href="#Cmmi10-68" transform="translate(0 0.609375)"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(57.617188 -12.31875) scale(0.7)"/>
      </g>
     </g>
     <g id="patch_10">
-     <path d="M 346.82 43.12875 
-L 370.82 43.12875 
-L 370.82 34.72875 
-L 346.82 34.72875 
-L 346.82 43.12875 
+     <path d="M 346.7 43.12875 
+L 370.7 43.12875 
+L 370.7 34.72875 
+L 346.7 34.72875 
+L 346.7 43.12875 
 z
 " style="fill: none; stroke: #e24a33; stroke-linejoin: miter"/>
     </g>
     <g id="text_8">
-     <!-- $h_3$ -->
-     <g style="fill: #1a1a1a" transform="translate(380.42 43.12875) scale(0.12 -0.12)">
+     <!-- $\mathit{h}_3$ -->
+     <g style="fill: #1a1a1a" transform="translate(380.3 43.12875) scale(0.12 -0.12)">
       <defs>
        <path id="LatinModernMath-Regular-33" d="M 2925 1094 
 C 2925 1619 2522 2118 1856 2253 
@@ -974,8 +994,8 @@ C 2342 -141 2925 442 2925 1094
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(0 0.59375)"/>
-      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(56.354131 -12.334375) scale(0.7)"/>
+      <use xlink:href="#Cmmi10-68" transform="translate(0 0.609375)"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(57.617188 -12.31875) scale(0.7)"/>
      </g>
     </g>
    </g>
@@ -1651,8 +1671,8 @@ z
      </g>
     </g>
     <g id="text_17">
-     <!-- $\frac{h_2 - h_3}{h_2 + h_3}$ -->
-     <g style="fill: #1a1a1a" transform="translate(24.66 278.683953) rotate(-90) scale(0.18 -0.18)">
+     <!-- $\frac{\mathit{h}_2 - \mathit{h}_3}{\mathit{h}_2 + \mathit{h}_3}$ -->
+     <g style="fill: #1a1a1a" transform="translate(24.66 278.863953) rotate(-90) scale(0.18 -0.18)">
       <defs>
        <path id="LatinModernMath-Regular-2b" d="M 4621 1600 
 C 4621 1670 4563 1728 4493 1728 
@@ -1674,21 +1694,21 @@ C 4563 1472 4621 1530 4621 1600
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(0 48.415625) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(39.447892 39.365938) scale(0.49)"/>
-      <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(77.747181 48.415625) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(144.498189 48.415625) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(183.946081 39.365938) scale(0.49)"/>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(0 -41.547969) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(39.447892 -50.597656) scale(0.49)"/>
-      <use xlink:href="#LatinModernMath-Regular-2b" transform="translate(77.747181 -41.547969) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(144.498189 -41.547969) scale(0.7)"/>
-      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(183.946081 -50.597656) scale(0.49)"/>
-      <path d="M 0 13.286406 
-L 0 19.536406 
-L 209.954354 19.536406 
-L 209.954354 13.286406 
-L 0 13.286406 
+      <use xlink:href="#Cmmi10-68" transform="translate(0 48.426563) scale(0.7)"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(40.332031 39.376875) scale(0.49)"/>
+      <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(78.631321 48.426563) scale(0.7)"/>
+      <use xlink:href="#Cmmi10-68" transform="translate(145.382328 48.426563) scale(0.7)"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(185.714359 39.376875) scale(0.49)"/>
+      <use xlink:href="#Cmmi10-68" transform="translate(0 -41.526094) scale(0.7)"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(40.332031 -50.575781) scale(0.49)"/>
+      <use xlink:href="#LatinModernMath-Regular-2b" transform="translate(78.631321 -41.526094) scale(0.7)"/>
+      <use xlink:href="#Cmmi10-68" transform="translate(145.382328 -41.526094) scale(0.7)"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(185.714359 -50.575781) scale(0.49)"/>
+      <path d="M 0 13.297344 
+L 0 19.547344 
+L 211.722633 19.547344 
+L 211.722633 13.297344 
+L 0 13.297344 
 z
 "/>
      </g>

--- a/docs/img/asymmetry_comparison_advanced.svg
+++ b/docs/img/asymmetry_comparison_advanced.svg
@@ -1315,7 +1315,7 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- $\mathrm{\mathbf{LMN\,\,3}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{dt}=(1 + 0.3)\,fb^{-1}$ -->
+    <!-- $\mathrm{\mathbf{LMN\,\,3}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d\mathit{t}}=(1 + 0.3)\,fb^{-1}$ -->
     <g style="fill: #1a1a1a" transform="translate(74.48 16.92) scale(0.12 -0.12)">
      <defs>
       <path id="Cmb10-4c" d="M 219 0 
@@ -1908,30 +1908,41 @@ Q 769 1119 795 928
 Q 822 738 909 556 
 z
 " transform="scale(0.015625)"/>
-      <path id="Cmr10-74" d="M 653 769 
-L 653 2534 
-L 122 2534 
-L 122 2700 
-Q 541 2700 737 3090 
-Q 934 3481 934 3938 
-L 1119 3938 
-L 1119 2759 
-L 2022 2759 
-L 2022 2534 
-L 1119 2534 
-L 1119 781 
-Q 1119 516 1208 316 
-Q 1297 116 1528 116 
-Q 1747 116 1844 327 
-Q 1941 538 1941 781 
-L 1941 1159 
-L 2125 1159 
-L 2125 769 
-Q 2125 569 2051 373 
-Q 1978 178 1834 53 
-Q 1691 -72 1484 -72 
-Q 1100 -72 876 158 
-Q 653 388 653 769 
+      <path id="Cmmi10-74" d="M 397 519 
+Q 397 613 416 697 
+L 878 2534 
+L 206 2534 
+Q 141 2534 141 2619 
+Q 166 2759 225 2759 
+L 934 2759 
+L 1191 3803 
+Q 1216 3888 1291 3947 
+Q 1366 4006 1459 4006 
+Q 1541 4006 1595 3957 
+Q 1650 3909 1650 3828 
+Q 1650 3809 1648 3798 
+Q 1647 3788 1644 3775 
+L 1388 2759 
+L 2047 2759 
+Q 2113 2759 2113 2675 
+Q 2109 2659 2100 2621 
+Q 2091 2584 2075 2559 
+Q 2059 2534 2028 2534 
+L 1331 2534 
+L 872 684 
+Q 825 503 825 372 
+Q 825 97 1013 97 
+Q 1294 97 1511 361 
+Q 1728 625 1844 941 
+Q 1869 978 1894 978 
+L 1972 978 
+Q 1997 978 2012 961 
+Q 2028 944 2028 922 
+Q 2028 909 2022 903 
+Q 1881 516 1612 222 
+Q 1344 -72 997 -72 
+Q 744 -72 570 93 
+Q 397 259 397 519 
 z
 " transform="scale(0.015625)"/>
       <path id="LatinModernMath-Regular-3d" d="M 4621 2221 
@@ -2114,19 +2125,19 @@ z
      <use xlink:href="#LatinModernMath-Regular-222b" transform="translate(877.76497 0.5)"/>
      <use xlink:href="#Cmsy10-4c" transform="translate(958.897408 0.5)"/>
      <use xlink:href="#Cmr10-64" transform="translate(1042.426347 0.5)"/>
-     <use xlink:href="#Cmr10-74" transform="translate(1097.943925 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-3d" transform="translate(1154.320878 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-28" transform="translate(1249.67946 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1288.579454 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-2b" transform="translate(1356.138032 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1451.496614 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(1501.496598 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(1529.296586 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-29" transform="translate(1579.296571 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1632.829019 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-62" transform="translate(1663.42901 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(1719.783141 30.665625) scale(0.7)"/>
-     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1774.243133 30.665625) scale(0.7)"/>
+     <use xlink:href="#Cmmi10-74" transform="translate(1097.943925 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-3d" transform="translate(1151.586503 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-28" transform="translate(1246.945085 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1285.845079 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-2b" transform="translate(1353.403657 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1448.762239 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(1498.762223 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(1526.562211 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-29" transform="translate(1576.562196 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1630.094644 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-62" transform="translate(1660.694635 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(1717.048766 30.665625) scale(0.7)"/>
+     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1771.508758 30.665625) scale(0.7)"/>
     </g>
    </g>
    <g id="legend_1">

--- a/docs/img/asymmetry_comparison_advanced.svg
+++ b/docs/img/asymmetry_comparison_advanced.svg
@@ -1315,7 +1315,7 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- $\mathrm{\mathbf{LMN\,\,3}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d\mathit{t}}=(1 + 0.3)\,fb^{-1}$ -->
+    <!-- $\mathrm{\mathbf{LMN\,\,3}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d}\mathit{t}=(1 + 0.3)\,fb^{-1}$ -->
     <g style="fill: #1a1a1a" transform="translate(74.48 16.92) scale(0.12 -0.12)">
      <defs>
       <path id="Cmb10-4c" d="M 219 0 

--- a/docs/img/model_examples_stacked.svg
+++ b/docs/img/model_examples_stacked.svg
@@ -2053,8 +2053,8 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- $\mathrm{\mathbf{Beast\,\,III}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{dt}=200\,fb^{-1}$ -->
-    <g style="fill: #1a1a1a" transform="translate(198.2 16.92) scale(0.12 -0.12)">
+    <!-- $\mathrm{\mathbf{Beast\,\,III}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d\mathit{t}}=200\,fb^{-1}$ -->
+    <g style="fill: #1a1a1a" transform="translate(198.56 16.92) scale(0.12 -0.12)">
      <defs>
       <path id="Cmb10-42" d="M 219 0 
 L 219 325 
@@ -2708,30 +2708,41 @@ Q 769 1119 795 928
 Q 822 738 909 556 
 z
 " transform="scale(0.015625)"/>
-      <path id="Cmr10-74" d="M 653 769 
-L 653 2534 
-L 122 2534 
-L 122 2700 
-Q 541 2700 737 3090 
-Q 934 3481 934 3938 
-L 1119 3938 
-L 1119 2759 
-L 2022 2759 
-L 2022 2534 
-L 1119 2534 
-L 1119 781 
-Q 1119 516 1208 316 
-Q 1297 116 1528 116 
-Q 1747 116 1844 327 
-Q 1941 538 1941 781 
-L 1941 1159 
-L 2125 1159 
-L 2125 769 
-Q 2125 569 2051 373 
-Q 1978 178 1834 53 
-Q 1691 -72 1484 -72 
-Q 1100 -72 876 158 
-Q 653 388 653 769 
+      <path id="Cmmi10-74" d="M 397 519 
+Q 397 613 416 697 
+L 878 2534 
+L 206 2534 
+Q 141 2534 141 2619 
+Q 166 2759 225 2759 
+L 934 2759 
+L 1191 3803 
+Q 1216 3888 1291 3947 
+Q 1366 4006 1459 4006 
+Q 1541 4006 1595 3957 
+Q 1650 3909 1650 3828 
+Q 1650 3809 1648 3798 
+Q 1647 3788 1644 3775 
+L 1388 2759 
+L 2047 2759 
+Q 2113 2759 2113 2675 
+Q 2109 2659 2100 2621 
+Q 2091 2584 2075 2559 
+Q 2059 2534 2028 2534 
+L 1331 2534 
+L 872 684 
+Q 825 503 825 372 
+Q 825 97 1013 97 
+Q 1294 97 1511 361 
+Q 1728 625 1844 941 
+Q 1869 978 1894 978 
+L 1972 978 
+Q 1997 978 2012 961 
+Q 2028 944 2028 922 
+Q 2028 909 2022 903 
+Q 1881 516 1612 222 
+Q 1344 -72 997 -72 
+Q 744 -72 570 93 
+Q 397 259 397 519 
 z
 " transform="scale(0.015625)"/>
       <path id="LatinModernMath-Regular-3d" d="M 4621 2221 
@@ -2853,15 +2864,15 @@ z
      <use xlink:href="#LatinModernMath-Regular-222b" transform="translate(958.184891 0.5)"/>
      <use xlink:href="#Cmsy10-4c" transform="translate(1039.31733 0.5)"/>
      <use xlink:href="#Cmr10-64" transform="translate(1122.846269 0.5)"/>
-     <use xlink:href="#Cmr10-74" transform="translate(1178.363847 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-3d" transform="translate(1234.7408 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(1330.099382 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1380.099366 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1430.099351 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1494.73179 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-62" transform="translate(1525.331781 0.5)"/>
-     <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(1581.685912 30.665625) scale(0.7)"/>
-     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1636.145904 30.665625) scale(0.7)"/>
+     <use xlink:href="#Cmmi10-74" transform="translate(1178.363847 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-3d" transform="translate(1232.006425 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(1327.365007 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1377.364991 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(1427.364976 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1491.997415 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-62" transform="translate(1522.597406 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-2212" transform="translate(1578.951537 30.665625) scale(0.7)"/>
+     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(1633.411529 30.665625) scale(0.7)"/>
     </g>
    </g>
    <g id="legend_1">

--- a/docs/img/model_examples_stacked.svg
+++ b/docs/img/model_examples_stacked.svg
@@ -2053,7 +2053,7 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- $\mathrm{\mathbf{Beast\,\,III}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d\mathit{t}}=200\,fb^{-1}$ -->
+    <!-- $\mathrm{\mathbf{Beast\,\,III}\,\,preliminary}$ $\int\,\mathcal{L}\,\mathrm{d}\mathit{t}=200\,fb^{-1}$ -->
     <g style="fill: #1a1a1a" transform="translate(198.56 16.92) scale(0.12 -0.12)">
      <defs>
       <path id="Cmb10-42" d="M 219 0 

--- a/plothist/plothist_style.py
+++ b/plothist/plothist_style.py
@@ -340,7 +340,7 @@ def add_luminosity(
         text += " "
     if is_data:
         if lumi:
-            text += rf"$\int\,\mathcal{{L}}\,\mathrm{{d\mathit{{t}}}}={lumi}\,{lumi_unit}^{{-1}}$"
+            text += rf"$\int\,\mathcal{{L}}\,\mathrm{{d}}\mathit{{t}}={lumi}\,{lumi_unit}^{{-1}}$"
     else:
         text += r"$\mathrm{simulation}$"
 

--- a/plothist/plothist_style.py
+++ b/plothist/plothist_style.py
@@ -340,7 +340,7 @@ def add_luminosity(
         text += " "
     if is_data:
         if lumi:
-            text += rf"$\int\,\mathcal{{L}}\,\mathrm{{dt}}={lumi}\,{lumi_unit}^{{-1}}$"
+            text += rf"$\int\,\mathcal{{L}}\,\mathrm{{d\mathit{{t}}}}={lumi}\,{lumi_unit}^{{-1}}$"
     else:
         text += r"$\mathrm{simulation}$"
 


### PR DESCRIPTION
Variable should be in italic.
Also good to have an italic example in the doc because people are using by default `\textit{}` which doesn't work. Could add also a more explicit `\mathit{}` example in the doc.