### PR TITLE
Add troubleshooting instructions for installing Latin Modern fonts and Bugfix install_latin_modern_fonts.py script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ plothist
    :target: https://badge.fury.io/py/plothist
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.0.5-blue.svg
+.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.0.6-blue.svg
    :target: https://plothist.readthedocs.io/en/latest/
 .. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg
    :target: https://plothist.readthedocs.io/en/main/

--- a/docs/basics/1d_hist.rst
+++ b/docs/basics/1d_hist.rst
@@ -55,7 +55,7 @@ or stack them:
     The function ``make_hist()`` returns a `boost_histogram.Histogram <https://boost-histogram.readthedocs.io/en/latest/>`_ object that supports potentially weighted data. You may call the ``make_hist()`` function without input data and fill the histogram object later in your code. An advantage of separating the histogramming from the plotting is that you can plot large datasets without having to load all the data into memory (see `this tutorial <https://github.com/cyrraz/visualise-large-dataset>`_).
 
 .. warning::
-    Note that in `boost_histogram`, the upper edges of the bins are exclusive.
+    Note that in ``boost_histogram``, the upper edges of the bins are exclusive.
 
 Histogram with error bars
 =========================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,9 +36,9 @@ copyright = "2023-2024, Cyrille Praz, Tristan Fillinger"
 author = "Cyrille Praz, Tristan Fillinger"
 
 # The short X.Y version
-version = "1.0.5"
+version = "1.0.6"
 # The full version, including alpha/beta/rc tags
-release = "1.0.5"
+release = "1.0.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Content
     :maxdepth: 2
 
     usage/installation
+    usage/font_installation
 
 .. toctree::
     :maxdepth: 2
@@ -27,7 +28,6 @@ Content
     :caption: Utilities
 
     basics/variable_registry
-    usage/font_installation
     usage/style
     usage/utilities
     usage/plot_fitting_results

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Content
     :maxdepth: 2
 
     usage/installation
+    usage/font_installation
 
 .. toctree::
     :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,6 @@ Content
     :maxdepth: 2
 
     usage/installation
-    usage/font_installation
 
 .. toctree::
     :maxdepth: 2
@@ -28,6 +27,7 @@ Content
     :caption: Utilities
 
     basics/variable_registry
+    usage/font_installation
     usage/style
     usage/utilities
     usage/plot_fitting_results

--- a/docs/usage/font_installation.rst
+++ b/docs/usage/font_installation.rst
@@ -1,0 +1,51 @@
+.. _usage-fonts-label:
+
+=================
+Font installation
+=================
+
+Latin Modern fonts are used by default (Latin Modern Math, Latin Modern Roman, Latin Modern Sans).
+
+On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
+
+.. code-block:: bash
+
+    install_latin_modern_fonts
+
+Try to restart your python session and run ``import plothist`` again. If no warning is raised, the fonts are installed correctly and you can skip the rest of this section.
+
+Troubleshooting
+===============
+
+If the command doesn't exist, you can run the script manually. First you need to get the folder where ``plothist`` is installed. You can do this by running in a python console:
+
+.. code-block:: python
+
+   import plothist
+   plothist.__file__
+
+   > '/path/to/plothist/__init__.py'
+
+Then you can run the following command in a terminal:
+
+.. code-block:: bash
+
+   python3 /path/to/plothist/scripts/install_latin_modern_fonts.py
+
+If the command doesn't work, you may read the detailed procedure directly in the `python script <https://github.com/cyrraz/plothist/blob/main/plothist/scripts/install_latin_modern_fonts.py>`_ called by the command ``install_latin_modern_fonts`` and execute the commands line by line in a terminal.
+
+It was observed in some cases that, after the procedure above, you may need to move the font files ``latinmodern-math.otf``, ``latin-modern-roman/`` and ``latin-modern-sans/`` from ``~/.fonts/`` into another folder. To get an idea of where the fonts are installed on your system, you can run the following commands in a python console:
+
+.. code-block:: python
+
+   from matplotlib import font_manager
+   font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
+
+Make also sure to delete the cache of matplotlib, otherwise the fonts may not be loaded correctly. You can delete the cache folder by running in a python console:
+
+.. code-block:: python
+
+   import matplotlib
+   import subprocess
+   cache_dir = matplotlib.get_cachedir()
+   subprocess.run(["rm", "-rv", cache_dir])

--- a/docs/usage/font_installation.rst
+++ b/docs/usage/font_installation.rst
@@ -6,7 +6,7 @@ Font installation
 
 Latin Modern fonts are used by default (Latin Modern Math, Latin Modern Roman, Latin Modern Sans).
 
-On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
+On Linux/Ubuntu/MacOS, after installing ``plothist``, you can install the fonts by running on your terminal:
 
 .. code-block:: bash
 

--- a/docs/usage/style.rst
+++ b/docs/usage/style.rst
@@ -1,8 +1,8 @@
 .. _usage-style-label:
 
-=======================
-Style, fonts and colors
-=======================
+================
+Style and colors
+================
 
 Default style
 =============

--- a/docs/usage/style.rst
+++ b/docs/usage/style.rst
@@ -37,6 +37,24 @@ On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
 
 Try to restart your python session and run ``import plothist`` again. If no warning is raised, the fonts are installed correctly and you can skip the rest of this section.
 
+Troubleshooting
+---------------
+
+If the command doesn't exist, you can run the script manually. First you need to get the folder where ``plothist`` is installed. You can do this by running in a python console:
+
+.. code-block:: python
+
+   import plothist
+   plothist.__file__
+
+   > '/path/to/plothist/__init__.py'
+
+Then you can run the following command in a terminal:
+
+.. code-block:: bash
+
+   python3 /path/to/plothist/scripts/install_latin_modern_fonts.py
+
 If the command doesn't work, you may read the detailed procedure directly in the `python script <https://github.com/cyrraz/plothist/blob/main/plothist/scripts/install_latin_modern_fonts.py>`_ called by the command ``install_latin_modern_fonts`` and execute the commands line by line in a terminal.
 
 It was observed in some cases that, after the procedure above, you may need to move the font files ``latinmodern-math.otf``, ``latin-modern-roman/`` and ``latin-modern-sans/`` from ``~/.fonts/`` into another folder. To get an idea of where the fonts are installed on your system, you can run the following commands in a python console:

--- a/docs/usage/style.rst
+++ b/docs/usage/style.rst
@@ -22,57 +22,6 @@ Here are shown two simple comparison plots done with matplotlib functions only. 
    :width: 320
 
 
-.. _usage-fonts-label:
-
-Font installation
-=================
-
-Latin Modern fonts are used by default (Latin Modern Math, Latin Modern Roman, Latin Modern Sans).
-
-On Linux/Ubuntu/MacOS, you can install the fonts by running on your terminal:
-
-.. code-block:: bash
-
-    install_latin_modern_fonts
-
-Try to restart your python session and run ``import plothist`` again. If no warning is raised, the fonts are installed correctly and you can skip the rest of this section.
-
-Troubleshooting
----------------
-
-If the command doesn't exist, you can run the script manually. First you need to get the folder where ``plothist`` is installed. You can do this by running in a python console:
-
-.. code-block:: python
-
-   import plothist
-   plothist.__file__
-
-   > '/path/to/plothist/__init__.py'
-
-Then you can run the following command in a terminal:
-
-.. code-block:: bash
-
-   python3 /path/to/plothist/scripts/install_latin_modern_fonts.py
-
-If the command doesn't work, you may read the detailed procedure directly in the `python script <https://github.com/cyrraz/plothist/blob/main/plothist/scripts/install_latin_modern_fonts.py>`_ called by the command ``install_latin_modern_fonts`` and execute the commands line by line in a terminal.
-
-It was observed in some cases that, after the procedure above, you may need to move the font files ``latinmodern-math.otf``, ``latin-modern-roman/`` and ``latin-modern-sans/`` from ``~/.fonts/`` into another folder. To get an idea of where the fonts are installed on your system, you can run the following commands in a python console:
-
-.. code-block:: python
-
-   from matplotlib import font_manager
-   font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
-
-Make also sure to delete the cache of matplotlib, otherwise the fonts may not be loaded correctly. You can delete the cache folder by running in a python console:
-
-.. code-block:: python
-
-   import matplotlib
-   import subprocess
-   cache_dir = matplotlib.get_cachedir()
-   subprocess.run(["rm", "-rv", cache_dir])
-
 Color palettes
 ==============
 

--- a/plothist/__init__.py
+++ b/plothist/__init__.py
@@ -1,5 +1,5 @@
 """Plot histograms in a scalable way and a beautiful style."""
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 from .plotters import (
     create_comparison_figure,

--- a/plothist/scripts/install_latin_modern_fonts.py
+++ b/plothist/scripts/install_latin_modern_fonts.py
@@ -6,15 +6,19 @@ from pathlib import Path
 
 def install_latin_modern_fonts():
     """
-    Install Latin Modern fonts for matplotlib.
+    Install Latin Modern fonts for matplotlib and clean the font cache.
     """
     if platform.system() == "Linux":  # Linux
-        font_directory = Path("~/.fonts/")
+        font_directory = Path(os.path.expanduser("~/.fonts/"))
         font_directory.mkdir(parents=True, exist_ok=True)
-        matplotlib_font_cache = "~/.cache/matplotlib/fontlist-v330.json"
+        matplotlib_font_cache = Path(
+            os.path.expanduser("~/.cache/matplotlib/fontlist-v330.json")
+        )
     if platform.system() == "Darwin":  # MacOS
         font_directory = Path(f"/Users/{os.getlogin()}/Library/Fonts")
-        matplotlib_font_cache = "~/.matplotlib/fontlist-v330.json"
+        matplotlib_font_cache = Path(
+            os.path.expanduser("~/.matplotlib/fontlist-v330.json")
+        )
 
     # Install Latin Modern Math
     subprocess.run(
@@ -38,10 +42,10 @@ def install_latin_modern_fonts():
         subprocess.run(
             [
                 "unzip",
+                "-o",
                 (font_directory / f"latin-modern-{lm}.zip").as_posix(),
                 "-d",
                 (font_directory / f"latin-modern-{lm}").as_posix(),
-                "-u",
             ]
         )
         subprocess.run(
@@ -51,13 +55,13 @@ def install_latin_modern_fonts():
     # Remove font cache
     try:
         subprocess.run(
-            ["rm", matplotlib_font_cache],
+            ["rm", "-v", matplotlib_font_cache.as_posix()],
             check=True,
         )
     except subprocess.CalledProcessError:
         print(
             f"""
-            Error while trying to remove {matplotlib_font_cache}, but maybe this is not needed.
+            Error while trying to remove {matplotlib_font_cache.as_posix()}, but maybe this is not needed.
             Check whether the Latin Modern fonts are now available in your matplotlib.
             If they are not, find the correct fontlist-XXX.json file in your matplotlib cache and remove it manually.
             """

--- a/plothist/scripts/install_latin_modern_fonts.py
+++ b/plothist/scripts/install_latin_modern_fonts.py
@@ -7,7 +7,7 @@ from pathlib import PosixPath
 def install_latin_modern_fonts():
     """
     Install Latin Modern Math, Latin Modern Roman and Latin Modern Sans fonts.
-    The font cache of matplotlib is removed, so that the new fonts are available in matplotlib.
+    The font cache of matplotlib is removed, so matplotlib will be forced to update its font list.
 
     The Latin Modern Math font is available at http://mirrors.ctan.org/fonts/lm-math/opentype/latinmodern-math.otf
     The Latin Modern Roman and Latin Modern Sans fonts are available at https://www.1001fonts.com/latin-modern-roman-font.html and https://www.1001fonts.com/latin-modern-sans-font.html

--- a/plothist/scripts/install_latin_modern_fonts.py
+++ b/plothist/scripts/install_latin_modern_fonts.py
@@ -1,23 +1,37 @@
 import subprocess
 import os
 import platform
-from pathlib import Path
+from pathlib import PosixPath
 
 
 def install_latin_modern_fonts():
     """
-    Install Latin Modern fonts for matplotlib and clean the font cache.
+    Install Latin Modern Math, Latin Modern Roman and Latin Modern Sans fonts.
+    The font cache of matplotlib is removed, so that the new fonts are available in matplotlib.
+
+    The Latin Modern Math font is available at http://mirrors.ctan.org/fonts/lm-math/opentype/latinmodern-math.otf
+    The Latin Modern Roman and Latin Modern Sans fonts are available at https://www.1001fonts.com/latin-modern-roman-font.html and https://www.1001fonts.com/latin-modern-sans-font.html
+
+    This function is only implemented for Linux and MacOS.
+
+    Raises:
+    ------
+        NotImplementedError: If the function is called on an unsupported operating system.
     """
     if platform.system() == "Linux":  # Linux
-        font_directory = Path(os.path.expanduser("~/.fonts/"))
+        font_directory = PosixPath("~/.fonts/").expanduser()
         font_directory.mkdir(parents=True, exist_ok=True)
-        matplotlib_font_cache = Path(
-            os.path.expanduser("~/.cache/matplotlib/fontlist-v330.json")
-        )
-    if platform.system() == "Darwin":  # MacOS
-        font_directory = Path(f"/Users/{os.getlogin()}/Library/Fonts")
-        matplotlib_font_cache = Path(
-            os.path.expanduser("~/.matplotlib/fontlist-v330.json")
+        matplotlib_font_cache = PosixPath(
+            "~/.cache/matplotlib/fontlist-v330.json"
+        ).expanduser()
+    elif platform.system() == "Darwin":  # MacOS
+        font_directory = PosixPath(f"/Users/{os.getlogin()}/Library/Fonts").expanduser()
+        matplotlib_font_cache = PosixPath(
+            "~/.matplotlib/fontlist-v330.json"
+        ).expanduser()
+    else:
+        raise NotImplementedError(
+            f"This script is only implemented for Linux and MacOS. If you manage to make it work on {platform.system()}, please submit a pull request."
         )
 
     # Install Latin Modern Math
@@ -25,7 +39,7 @@ def install_latin_modern_fonts():
         [
             "wget",
             "-P",
-            font_directory.as_posix(),
+            font_directory,
             "http://mirrors.ctan.org/fonts/lm-math/opentype/latinmodern-math.otf",
         ]
     )
@@ -35,7 +49,7 @@ def install_latin_modern_fonts():
             [
                 "wget",
                 "-P",
-                font_directory.as_posix(),
+                font_directory,
                 f"https://www.1001fonts.com/download/latin-modern-{lm}.zip",
             ]
         )
@@ -43,25 +57,23 @@ def install_latin_modern_fonts():
             [
                 "unzip",
                 "-o",
-                (font_directory / f"latin-modern-{lm}.zip").as_posix(),
+                (font_directory / f"latin-modern-{lm}.zip"),
                 "-d",
-                (font_directory / f"latin-modern-{lm}").as_posix(),
+                (font_directory / f"latin-modern-{lm}"),
             ]
         )
-        subprocess.run(
-            ["rm", "-f", (font_directory / f"latin-modern-{lm}.zip").as_posix()]
-        )
+        subprocess.run(["rm", "-f", (font_directory / f"latin-modern-{lm}.zip")])
 
     # Remove font cache
     try:
         subprocess.run(
-            ["rm", "-v", matplotlib_font_cache.as_posix()],
+            ["rm", "-v", matplotlib_font_cache],
             check=True,
         )
     except subprocess.CalledProcessError:
         print(
             f"""
-            Error while trying to remove {matplotlib_font_cache.as_posix()}, but maybe this is not needed.
+            Error while trying to remove {matplotlib_font_cache}, but maybe this is not needed.
             Check whether the Latin Modern fonts are now available in your matplotlib.
             If they are not, find the correct fontlist-XXX.json file in your matplotlib cache and remove it manually.
             """


### PR DESCRIPTION
`install_latin_modern_fonts` was not correctly installing the fonts.
They were installed in `\~/.fonts/`, plus the unzip command was not working.
Added some documentation if the command is not recognize by the system (happened once).