### PR TITLE
Add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: mixed-line-ending
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+        exclude: '.*\.svg$'
 
   - repo: https://github.com/psf/black
     rev: "24.2.0"


### PR DESCRIPTION
Added `.pre-commit-config.yaml` to integrate pre-commit hooks for automated code formatting and quality checks. This setup includes hooks for `black` for code formatting, `blacken-docs` for formatting code blocks in documentation, and various `pre-commit` hooks to ensure code quality and consistency. This addition aims to streamline our development workflow and enforce coding standards across the project.

See details here: https://pre-commit.com/