### PR TITLE
Fonts bugfix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ plothist
    :target: https://badge.fury.io/py/plothist
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.2.0-blue.svg
+.. |Docs from latest| image:: https://img.shields.io/badge/docs-v1.2.1-blue.svg
    :target: https://plothist.readthedocs.io/en/latest/
 .. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg
    :target: https://plothist.readthedocs.io/en/main/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,9 +36,9 @@ copyright = "2023-2024, Cyrille Praz, Tristan Fillinger"
 author = "Cyrille Praz, Tristan Fillinger"
 
 # The short X.Y version
-version = "1.2.0"
+version = "1.2.1"
 # The full version, including alpha/beta/rc tags
-release = "1.2.0"
+release = "1.2.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "matplotlib>=3.0",
     "pyyaml>=5.3.1",
     "scipy>=1.6.0",
-    "pytest>=7.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "matplotlib>=3.0",
     "pyyaml>=5.3.1",
     "scipy>=1.6.0",
+    "pytest>=7.0.0",
 ]
 
 [project.urls]

--- a/src/plothist/__init__.py
+++ b/src/plothist/__init__.py
@@ -1,6 +1,6 @@
 """Plot histograms in a scalable way and a beautiful style."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from .plotters import (
     create_comparison_figure,

--- a/src/plothist/scripts/install_latin_modern_fonts.py
+++ b/src/plothist/scripts/install_latin_modern_fonts.py
@@ -23,10 +23,10 @@ def _get_wget_version():
     version_string = subprocess.check_output(
         ["wget", "--version"], universal_newlines=True
     )
-    # Try to find the version number in the format "1.XX.XX"
+    # Try to find the version number in the format "XX.XX.XX"
     version_match = re.search(r"(\d+\.\d+\.\d+)", version_string)
     if not version_match:
-        # Try to find the version number in the format "1.XX"
+        # Try to find the version number in the format "XX.XX"
         version_match = re.search(r"(\d+\.\d+)", version_string)
     if version_match:
         version = version_match.group(1)

--- a/src/plothist/scripts/install_latin_modern_fonts.py
+++ b/src/plothist/scripts/install_latin_modern_fonts.py
@@ -153,25 +153,42 @@ def install_latin_modern_fonts():
 
     # Install Latin Modern Roman and Latin Modern Sans
     for lm in ["roman", "sans"]:
-        _download_font(
-            f"https://www.1001fonts.com/download/latin-modern-{lm}.zip",
-            font_directory,
-            f"Latin Modern {lm}",
-        )
-        print(f"Unzipping Latin Modern {lm}...")
+        attempt = 0
+        max_attempt = 10
+        success = False
 
-        subprocess.run(
-            [
-                "unzip",
-                "-o",
-                (font_directory / f"latin-modern-{lm}.zip"),
-                "-d",
-                (font_directory / f"latin-modern-{lm}"),
-            ]
-        )
-        subprocess.run(["rm", "-f", (font_directory / f"latin-modern-{lm}.zip")])
+        while not success and attempt < max_attempt:
+            _download_font(
+                f"https://www.1001fonts.com/download/latin-modern-{lm}.zip",
+                font_directory,
+                f"Latin Modern {lm}",
+            )
+            print(f"Unzipping Latin Modern {lm}...")
+
+            result = subprocess.run(
+                [
+                    "unzip",
+                    "-o",
+                    (font_directory / f"latin-modern-{lm}.zip"),
+                    "-d",
+                    (font_directory / f"latin-modern-{lm}"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            success = result.returncode == 0
+            if not success:
+                # Print the output to the terminal
+                print("Try", attempt + 1, "of", max_attempt)
+                print("STDOUT:", result.stdout)
+                print("STDERR:", result.stderr)
+                # Increment attempt counter and wait before the next attempt
+                attempt += 1
+                time.sleep(1)
+                subprocess.run(["rm", "-f", (font_directory / f"latin-modern-{lm}.zip")])
 
         print(f"Latin Modern {lm} installed successfully.\n")
+        subprocess.run(["rm", "-f", (font_directory / f"latin-modern-{lm}.zip")])
 
     # Remove font cache
     try:

--- a/src/plothist/scripts/install_latin_modern_fonts.py
+++ b/src/plothist/scripts/install_latin_modern_fonts.py
@@ -20,22 +20,19 @@ def _get_wget_version():
     RuntimeError
         If the version of wget could not be determined.
     """
-    try:
-        version_string = subprocess.check_output(
-            ["wget", "--version"], universal_newlines=True
-        )
-        # Try to find the version number in the format "1.XX.XX"
-        version_match = re.search(r"(\d+\.\d+\.\d+)", version_string)
-        if not version_match:
-            # Try to find the version number in the format "1.XX"
-            version_match = re.search(r"(\d+\.\d+)", version_string)
-        if version_match:
-            version = version_match.group(1)
-            return tuple(map(int, version.split(".")))
-        else:
-            raise RuntimeError("Could not determine wget version.")
-    except Exception as e:
-        return str(e)
+    version_string = subprocess.check_output(
+        ["wget", "--version"], universal_newlines=True
+    )
+    # Try to find the version number in the format "1.XX.XX"
+    version_match = re.search(r"(\d+\.\d+\.\d+)", version_string)
+    if not version_match:
+        # Try to find the version number in the format "1.XX"
+        version_match = re.search(r"(\d+\.\d+)", version_string)
+    if version_match:
+        version = version_match.group(1)
+        return tuple(map(int, version.split(".")))
+    else:
+        raise RuntimeError("Could not determine wget version.")
 
 
 def _get_install_command(url, font_directory):

--- a/src/plothist/scripts/install_latin_modern_fonts.py
+++ b/src/plothist/scripts/install_latin_modern_fonts.py
@@ -7,12 +7,27 @@ import re
 
 
 def _get_wget_version():
+    """
+    Get the version of wget.
+
+    Returns
+    -------
+    tuple or str
+        The version of wget as a tuple of integers.
+
+    Raises
+    ------
+    RuntimeError
+        If the version of wget could not be determined.
+    """
     try:
         version_string = subprocess.check_output(
             ["wget", "--version"], universal_newlines=True
         )
+        # Try to find the version number in the format "1.XX.XX"
         version_match = re.search(r"(\d+\.\d+\.\d+)", version_string)
         if not version_match:
+            # Try to find the version number in the format "1.XX"
             version_match = re.search(r"(\d+\.\d+)", version_string)
         if version_match:
             version = version_match.group(1)

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -2,7 +2,6 @@ import os
 import yaml
 import subprocess
 import plothist
-from pytest import fail
 import hashlib
 import warnings
 import sys
@@ -34,6 +33,9 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
             stacklevel=2,
         )
         return 1
+
+    if check_svg:
+        from pytest import fail
 
     plothist_folder = (
         plothist.__path__[0]
@@ -150,7 +152,7 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
                 capture_output=True,
                 text=True,
             )
-            if result.returncode != 0:
+            if result.returncode != 0 and check_svg:
                 fail(f"Error while redoing {file}:\n{result.stderr}\n{result.stdout}")
 
     # Move the svg files to the img folder

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -111,14 +111,12 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
     svg_metadata = "metadata=" + str(svg_metadata)
 
     if check_svg:
+        from pytest import fail
         img_hashes = {}
         for file in os.listdir(img_folder):
             if file.endswith(".svg"):
                 with open(os.path.join(img_folder, file), "r") as f:
                     img_hashes[file] = hashlib.sha256(f.read().encode()).hexdigest()
-
-    if check_svg:
-        from pytest import fail
 
     # Iterate through all subfolders and files in the source folder
     for root, dirs, files in os.walk(example_folder):

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -34,9 +34,6 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
         )
         return 1
 
-    if check_svg:
-        from pytest import fail
-
     plothist_folder = (
         plothist.__path__[0]
         if os.environ.get("PLOTHIST_PATH") is None
@@ -119,6 +116,9 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
             if file.endswith(".svg"):
                 with open(os.path.join(img_folder, file), "r") as f:
                     img_hashes[file] = hashlib.sha256(f.read().encode()).hexdigest()
+
+    if check_svg:
+        from pytest import fail
 
     # Iterate through all subfolders and files in the source folder
     for root, dirs, files in os.walk(example_folder):


### PR DESCRIPTION
The `install_latin_modern_fonts` crashes if `wget` is too old, and it appears that `wget` is indeed old on some computing centers...
Also, `pytest` is used in the `install_latin_modern_fonts` and `plothist_make_examples`, so we should add it as a dependency -> Not needed anymore