### PR TITLE
Add text upgrade

### DIFF
--- a/docs/advanced/model_examples.rst
+++ b/docs/advanced/model_examples.rst
@@ -132,7 +132,7 @@ An example with stacked histograms:
    :width: 500
 
 .. note::
-    The function :func:`add_luminosity() <plothist.plothist_style.add_luminosity>` is used here to add information on the luminosity used for the data. This is common practice in high energy physics, and this function is provided to make it easy to add this information to the plot.
+    The function :func:`add_luminosity() <plothist.plothist_style.add_luminosity>` is used here to add information on the luminosity used for the data. This is common practice in high energy physics, and this function is provided to make it easy to add this information to the plot. Is it a wrapper around :func:`add_text() <plothist.plothist_style.add_text>`.
 
 
 Unstacked histograms

--- a/docs/advanced/model_examples.rst
+++ b/docs/advanced/model_examples.rst
@@ -132,7 +132,7 @@ An example with stacked histograms:
    :width: 500
 
 .. note::
-    The function :func:`add_luminosity() <plothist.plothist_style.add_luminosity>` is used here to add information on the luminosity used for the data. This is common practice in high energy physics, and this function is provided to make it easy to add this information to the plot. Is it a wrapper around :func:`add_text() <plothist.plothist_style.add_text>`.
+    The function :func:`add_luminosity() <plothist.plothist_style.add_luminosity>` is used here to add information on the `integrated luminosity <https://en.wikipedia.org/wiki/Luminosity_(scattering_theory)>`_ used for the data. This is common practice in high energy physics, and this function is provided to make it easy to add this information to the plot. It is a wrapper around :func:`add_text() <plothist.plothist_style.add_text>`.
 
 
 Unstacked histograms

--- a/docs/examples/utility/add_text_example.py
+++ b/docs/examples/utility/add_text_example.py
@@ -1,0 +1,35 @@
+"""
+add_text Example
+================
+
+Multiple examples of combinations of x and y aliases for the add_text function.
+"""
+###
+from plothist import add_text
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots()
+
+positions = [
+    ("right_in", "top_in"),
+    ("left_in", "top_in"),
+    ("left_in", "bottom_in"),
+    ("right_in", "bottom_in"),
+    ("right", "top_out"),
+    ("left", "top_out"),
+    ("right_out", "top_in"),
+    ("right_out", "bottom_in"),
+    ("right", "bottom_out"),
+    ("left", "bottom_out"),
+]
+
+for x, y in positions:
+    x_label = x.replace("_", "\_")
+    y_label = y.replace("_", "\_")
+    add_text(
+        f"$\\mathtt{{add\\_text()}}$\n$\\mathtt{{x = {x_label}}}$\n$\\mathtt{{y = {y_label}}}$",
+        x=x,
+        y=y,
+    )
+
+fig.savefig("add_text_example.svg", bbox_inches="tight")

--- a/docs/examples/utility/add_text_example.py
+++ b/docs/examples/utility/add_text_example.py
@@ -28,7 +28,17 @@ for x, y in positions:
     x_label = x.replace("_", "\_")
     y_label = y.replace("_", "\_")
     add_text(
-        f"$\\mathtt{{add\\_text()}}$\n$\\mathtt{{x = {x_label}}}$\n$\\mathtt{{y = {y_label}}}$",
+        "$\mathtt{add\_text()}$"
+        + "\n"
+        + "$\mathtt{x = }$"
+        + '"$\mathtt{'
+        + x_label
+        + '}$"'
+        + "\n"
+        + "$\mathtt{y = }$"
+        + '"$\mathtt{'
+        + y_label
+        + '}$"',
         x=x,
         y=y,
     )

--- a/docs/examples/utility/add_text_example.py
+++ b/docs/examples/utility/add_text_example.py
@@ -4,6 +4,7 @@ add_text Example
 
 Multiple examples of combinations of x and y aliases for the add_text function.
 """
+
 ###
 from plothist import add_text
 import matplotlib.pyplot as plt

--- a/docs/img/add_text_example.svg
+++ b/docs/img/add_text_example.svg
@@ -1,0 +1,1874 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="456.656pt" height="337.7892pt" viewBox="0 0 456.656 337.7892" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>カリビアンカフェ</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 337.7892 
+L 456.656 337.7892 
+L 456.656 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 31.4 268.6866 
+L 366.2 268.6866 
+L 366.2 46.9266 
+L 31.4 46.9266 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 31.4 268.6866 
+L 31.4 46.9266 
+" style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 366.2 268.6866 
+L 366.2 46.9266 
+" style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 31.4 268.6866 
+L 366.2 268.6866 
+" style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 31.4 46.9266 
+L 366.2 46.9266 
+" style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m8dec1b3d1d" d="M 0 0 
+L 0 -6 
+" style="stroke: #1a1a1a; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="31.4" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- $\mathdefault{0.0}$ -->
+      <g style="fill: #1a1a1a" transform="translate(21.8 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-30" d="M 2944 2048 
+C 2944 2560 2912 3072 2688 3546 
+C 2394 4160 1869 4262 1600 4262 
+C 1216 4262 749 4096 486 3501 
+C 282 3059 250 2560 250 2048 
+C 250 1568 275 992 538 506 
+C 813 -13 1280 -141 1594 -141 
+C 1939 -141 2426 -6 2707 602 
+C 2912 1043 2944 1542 2944 2048 
+z
+M 2413 2125 
+C 2413 1645 2413 1210 2342 800 
+C 2246 192 1882 0 1594 0 
+C 1344 0 966 160 851 774 
+C 781 1158 781 1747 781 2125 
+C 781 2534 781 2957 832 3302 
+C 954 4064 1434 4122 1594 4122 
+C 1805 4122 2227 4006 2349 3373 
+C 2413 3014 2413 2528 2413 2125 
+z
+" transform="scale(0.015625)"/>
+        <path id="LatinModernMath-Regular-2e" d="M 1229 339 
+C 1229 525 1075 678 890 678 
+C 704 678 550 525 550 339 
+C 550 154 704 0 890 0 
+C 1075 0 1229 154 1229 339 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="98.36" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- $\mathdefault{0.2}$ -->
+      <g style="fill: #1a1a1a" transform="translate(88.76 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-32" d="M 2874 1114 
+L 2714 1114 
+C 2682 922 2637 640 2573 544 
+C 2528 493 2106 493 1965 493 
+L 813 493 
+L 1491 1152 
+C 2490 2035 2874 2381 2874 3021 
+C 2874 3750 2298 4262 1517 4262 
+C 794 4262 320 3674 320 3104 
+C 320 2746 640 2746 659 2746 
+C 768 2746 992 2822 992 3085 
+C 992 3251 877 3418 653 3418 
+C 602 3418 589 3418 570 3411 
+C 717 3827 1062 4064 1434 4064 
+C 2016 4064 2291 3546 2291 3021 
+C 2291 2509 1971 2003 1619 1606 
+L 390 237 
+C 320 166 320 154 320 0 
+L 2694 0 
+L 2874 1114 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-32" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="165.32" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- $\mathdefault{0.4}$ -->
+      <g style="fill: #1a1a1a" transform="translate(155.72 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-34" d="M 3014 1056 
+L 3014 1254 
+L 2374 1254 
+L 2374 4166 
+C 2374 4294 2374 4333 2272 4333 
+C 2214 4333 2195 4333 2144 4256 
+L 179 1254 
+L 179 1056 
+L 1882 1056 
+L 1882 499 
+C 1882 269 1869 198 1395 198 
+L 1261 198 
+L 1261 0 
+C 1523 19 1856 19 2125 19 
+C 2394 19 2733 19 2995 0 
+L 2995 198 
+L 2861 198 
+C 2387 198 2374 269 2374 499 
+L 2374 1056 
+L 3014 1056 
+z
+M 1920 1254 
+L 358 1254 
+L 1920 3642 
+L 1920 1254 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.296875)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.296875)"/>
+       <use xlink:href="#LatinModernMath-Regular-34" transform="translate(77.799973 0.296875)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="232.28" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- $\mathdefault{0.6}$ -->
+      <g style="fill: #1a1a1a" transform="translate(222.68 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-36" d="M 2925 1306 
+C 2925 2118 2355 2733 1645 2733 
+C 1210 2733 973 2406 845 2099 
+L 845 2253 
+C 845 3872 1638 4102 1965 4102 
+C 2118 4102 2387 4064 2528 3846 
+C 2432 3846 2176 3846 2176 3558 
+C 2176 3360 2330 3264 2470 3264 
+C 2573 3264 2765 3322 2765 3571 
+C 2765 3955 2483 4262 1952 4262 
+C 1133 4262 269 3437 269 2022 
+C 269 314 1011 -141 1606 -141 
+C 2317 -141 2925 461 2925 1306 
+z
+M 2349 1312 
+C 2349 1005 2349 685 2240 454 
+C 2048 70 1754 38 1606 38 
+C 1203 38 1011 422 973 518 
+C 858 819 858 1331 858 1446 
+C 858 1946 1062 2586 1638 2586 
+C 1741 2586 2035 2586 2234 2189 
+C 2349 1952 2349 1626 2349 1312 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-36" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="299.24" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- $\mathdefault{0.8}$ -->
+      <g style="fill: #1a1a1a" transform="translate(289.64 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-38" d="M 2925 1075 
+C 2925 1306 2854 1594 2611 1862 
+C 2490 1997 2387 2061 1978 2317 
+C 2438 2554 2752 2886 2752 3309 
+C 2752 3898 2182 4262 1600 4262 
+C 960 4262 442 3789 442 3194 
+C 442 3078 454 2790 723 2490 
+C 794 2413 1030 2253 1190 2144 
+C 819 1958 269 1600 269 966 
+C 269 288 922 -141 1594 -141 
+C 2317 -141 2925 390 2925 1075 
+z
+M 2470 3309 
+C 2470 2944 2221 2637 1837 2413 
+L 1043 2925 
+C 749 3117 723 3334 723 3443 
+C 723 3834 1139 4102 1594 4102 
+C 2061 4102 2470 3770 2470 3309 
+z
+M 2605 845 
+C 2605 371 2125 38 1600 38 
+C 1050 38 589 435 589 966 
+C 589 1338 794 1747 1338 2048 
+L 2125 1549 
+C 2304 1427 2605 1235 2605 845 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-38" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8dec1b3d1d" x="366.2" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- $\mathdefault{1.0}$ -->
+      <g style="fill: #1a1a1a" transform="translate(356.6 287.097537) scale(0.15 -0.15)">
+       <defs>
+        <path id="LatinModernMath-Regular-31" d="M 2682 0 
+L 2682 198 
+L 2477 198 
+C 1901 198 1882 269 1882 506 
+L 1882 4096 
+C 1882 4250 1882 4262 1734 4262 
+C 1338 3853 774 3853 570 3853 
+L 570 3654 
+C 698 3654 1075 3654 1408 3821 
+L 1408 506 
+C 1408 275 1389 198 813 198 
+L 608 198 
+L 608 0 
+C 832 19 1389 19 1645 19 
+C 1901 19 2458 19 2682 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#LatinModernMath-Regular-31" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <defs>
+       <path id="m131efc0c90" d="M 0 0 
+L 0 -3 
+" style="stroke: #1a1a1a; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m131efc0c90" x="48.14" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m131efc0c90" x="64.88" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m131efc0c90" x="81.62" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m131efc0c90" x="115.1" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m131efc0c90" x="131.84" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m131efc0c90" x="148.58" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m131efc0c90" x="182.06" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m131efc0c90" x="198.8" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m131efc0c90" x="215.54" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m131efc0c90" x="249.02" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m131efc0c90" x="265.76" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m131efc0c90" x="282.5" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m131efc0c90" x="315.98" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m131efc0c90" x="332.72" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m131efc0c90" x="349.46" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_22">
+      <defs>
+       <path id="mc947610920" d="M 0 0 
+L 6 0 
+" style="stroke: #1a1a1a; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{0.0}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 273.892069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="224.3346" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{0.2}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 229.540069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-32" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="179.9826" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{0.4}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 185.188069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.296875)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.296875)"/>
+       <use xlink:href="#LatinModernMath-Regular-34" transform="translate(77.799973 0.296875)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="135.6306" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{0.6}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 140.836069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-36" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="91.2786" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{0.8}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 96.484069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-38" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mc947610920" x="31.4" y="46.9266" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{1.0}$ -->
+      <g style="fill: #1a1a1a" transform="translate(7.2 52.132069) scale(0.15 -0.15)">
+       <use xlink:href="#LatinModernMath-Regular-31" transform="translate(0 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_28">
+      <defs>
+       <path id="m5f9d1e6504" d="M 0 0 
+L 3 0 
+" style="stroke: #1a1a1a; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="257.5986" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="246.5106" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="235.4226" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="213.2466" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="202.1586" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="191.0706" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="168.8946" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="157.8066" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="146.7186" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="124.5426" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="113.4546" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="102.3666" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="80.1906" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="69.1026" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="58.0146" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(296.396 64.797) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmtt10-61" d="M 341 850 
+Q 341 1213 672 1423 
+Q 1003 1634 1439 1712 
+Q 1875 1791 2259 1791 
+L 2259 1844 
+Q 2259 2106 2031 2253 
+Q 1803 2400 1522 2400 
+Q 1234 2400 1094 2375 
+Q 1100 2375 1100 2322 
+Q 1100 2203 1012 2115 
+Q 925 2028 806 2028 
+Q 675 2028 590 2118 
+Q 506 2209 506 2338 
+Q 506 2650 804 2733 
+Q 1103 2816 1538 2816 
+Q 1813 2816 2091 2702 
+Q 2369 2588 2547 2372 
+Q 2725 2156 2725 1869 
+L 2725 475 
+Q 2725 416 3175 416 
+Q 3334 397 3353 238 
+L 3353 178 
+Q 3334 19 3175 0 
+L 3066 0 
+Q 2797 0 2614 39 
+Q 2431 78 2322 219 
+Q 1959 -38 1363 -38 
+Q 1109 -38 871 71 
+Q 634 181 487 382 
+Q 341 584 341 850 
+z
+M 806 844 
+Q 806 631 1004 504 
+Q 1203 378 1441 378 
+Q 1691 378 1894 447 
+Q 1997 484 2119 565 
+Q 2241 647 2241 722 
+Q 2241 719 2250 767 
+Q 2259 816 2259 844 
+L 2259 1388 
+Q 2113 1388 1869 1363 
+Q 1625 1338 1387 1280 
+Q 1150 1222 978 1111 
+Q 806 1000 806 844 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-64" d="M 1472 -38 
+Q 1194 -38 964 81 
+Q 734 200 567 403 
+Q 400 606 309 861 
+Q 219 1116 219 1381 
+Q 219 1653 316 1908 
+Q 413 2163 595 2366 
+Q 778 2569 1020 2683 
+Q 1263 2797 1538 2797 
+Q 1953 2797 2278 2522 
+L 2278 3494 
+L 1913 3494 
+Q 1753 3513 1734 3675 
+L 1734 3731 
+Q 1753 3891 1913 3909 
+L 2566 3909 
+Q 2722 3891 2747 3731 
+L 2747 416 
+L 3109 416 
+Q 3188 406 3234 362 
+Q 3281 319 3291 238 
+L 3291 178 
+Q 3281 103 3234 56 
+Q 3188 9 3109 0 
+L 2456 0 
+Q 2381 9 2334 56 
+Q 2288 103 2278 178 
+L 2278 306 
+Q 1919 -38 1472 -38 
+z
+M 1509 378 
+Q 1800 378 2006 606 
+Q 2213 834 2278 1141 
+L 2278 1813 
+Q 2209 2053 2015 2217 
+Q 1822 2381 1575 2381 
+Q 1319 2381 1114 2237 
+Q 909 2094 796 1858 
+Q 684 1622 684 1375 
+Q 684 1144 786 908 
+Q 888 672 1075 525 
+Q 1263 378 1509 378 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-5f" d="M 569 -609 
+Q 478 -594 418 -531 
+Q 359 -469 359 -384 
+Q 359 -294 418 -231 
+Q 478 -169 569 -159 
+L 2784 -159 
+Q 2875 -169 2934 -228 
+Q 2994 -288 2994 -384 
+Q 2994 -475 2934 -534 
+Q 2875 -594 2784 -609 
+L 569 -609 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-74" d="M 966 819 
+L 966 2344 
+L 341 2344 
+Q 178 2363 159 2522 
+L 159 2578 
+Q 178 2741 341 2759 
+L 966 2759 
+L 966 3366 
+Q 984 3522 1147 3547 
+L 1253 3547 
+Q 1416 3522 1434 3366 
+L 1434 2759 
+L 2547 2759 
+Q 2625 2750 2670 2703 
+Q 2716 2656 2725 2578 
+L 2725 2522 
+Q 2706 2363 2547 2344 
+L 1434 2344 
+L 1434 844 
+Q 1434 378 1919 378 
+Q 2116 378 2261 512 
+Q 2406 647 2406 844 
+L 2406 878 
+Q 2416 953 2462 1000 
+Q 2509 1047 2584 1056 
+L 2694 1056 
+Q 2850 1038 2875 878 
+L 2875 819 
+Q 2875 563 2729 367 
+Q 2584 172 2356 67 
+Q 2128 -38 1875 -38 
+Q 1609 -38 1406 64 
+Q 1203 166 1084 361 
+Q 966 556 966 819 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-65" d="M 825 1209 
+Q 894 844 1194 611 
+Q 1494 378 1875 378 
+Q 2075 378 2254 470 
+Q 2434 563 2503 728 
+Q 2553 875 2681 891 
+L 2791 891 
+Q 2872 881 2920 826 
+Q 2969 772 2969 697 
+Q 2969 678 2967 667 
+Q 2966 656 2963 641 
+Q 2841 303 2523 132 
+Q 2206 -38 1825 -38 
+Q 1438 -38 1092 151 
+Q 747 341 544 666 
+Q 341 991 341 1388 
+Q 341 1675 447 1931 
+Q 553 2188 742 2389 
+Q 931 2591 1186 2703 
+Q 1441 2816 1728 2816 
+Q 2128 2816 2409 2633 
+Q 2691 2450 2830 2133 
+Q 2969 1816 2969 1416 
+Q 2969 1331 2919 1275 
+Q 2869 1219 2791 1209 
+L 825 1209 
+z
+M 831 1619 
+L 2491 1619 
+Q 2466 1844 2375 2020 
+Q 2284 2197 2121 2298 
+Q 1959 2400 1728 2400 
+Q 1516 2400 1323 2294 
+Q 1131 2188 1001 2006 
+Q 872 1825 831 1619 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-78" d="M 366 0 
+Q 203 19 184 178 
+L 184 238 
+Q 203 397 366 416 
+L 703 416 
+L 1472 1422 
+L 750 2344 
+L 403 2344 
+Q 244 2363 225 2522 
+L 225 2578 
+Q 234 2656 278 2703 
+Q 322 2750 403 2759 
+L 1338 2759 
+Q 1488 2741 1516 2578 
+L 1516 2522 
+Q 1488 2363 1338 2344 
+L 1216 2344 
+L 1656 1747 
+L 2094 2344 
+L 1959 2344 
+Q 1806 2363 1778 2522 
+L 1778 2578 
+Q 1791 2653 1839 2701 
+Q 1888 2750 1959 2759 
+L 2894 2759 
+Q 2969 2750 3016 2703 
+Q 3063 2656 3072 2578 
+L 3072 2522 
+Q 3053 2363 2894 2344 
+L 2553 2344 
+L 1850 1422 
+L 2638 416 
+L 2981 416 
+Q 3059 406 3106 362 
+Q 3153 319 3163 238 
+L 3163 178 
+Q 3153 103 3106 56 
+Q 3059 9 2981 0 
+L 2047 0 
+Q 1900 19 1869 178 
+L 1869 238 
+Q 1897 397 2047 416 
+L 2188 416 
+L 1656 1159 
+L 1153 416 
+L 1300 416 
+Q 1450 397 1478 238 
+L 1478 178 
+Q 1450 19 1300 0 
+L 366 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmr10-28" d="M 1984 -1588 
+Q 1628 -1306 1370 -942 
+Q 1113 -578 948 -165 
+Q 784 247 703 697 
+Q 622 1147 622 1600 
+Q 622 2059 703 2509 
+Q 784 2959 951 3375 
+Q 1119 3791 1378 4153 
+Q 1638 4516 1984 4788 
+Q 1984 4800 2016 4800 
+L 2075 4800 
+Q 2094 4800 2109 4783 
+Q 2125 4766 2125 4744 
+Q 2125 4716 2113 4703 
+Q 1800 4397 1592 4047 
+Q 1384 3697 1257 3301 
+Q 1131 2906 1075 2482 
+Q 1019 2059 1019 1600 
+Q 1019 -434 2106 -1491 
+Q 2125 -1509 2125 -1544 
+Q 2125 -1559 2108 -1579 
+Q 2091 -1600 2075 -1600 
+L 2016 -1600 
+Q 1984 -1600 1984 -1588 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmr10-29" d="M 416 -1600 
+Q 359 -1600 359 -1544 
+Q 359 -1516 372 -1503 
+Q 1466 -434 1466 1600 
+Q 1466 3634 384 4691 
+Q 359 4706 359 4744 
+Q 359 4766 376 4783 
+Q 394 4800 416 4800 
+L 475 4800 
+Q 494 4800 506 4788 
+Q 966 4425 1272 3906 
+Q 1578 3388 1720 2800 
+Q 1863 2213 1863 1600 
+Q 1863 1147 1786 708 
+Q 1709 269 1542 -157 
+Q 1375 -584 1119 -945 
+Q 863 -1306 506 -1588 
+Q 494 -1600 475 -1600 
+L 416 -1600 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(285.836 77.7915) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmr10-3d" d="M 481 850 
+Q 428 850 393 890 
+Q 359 931 359 978 
+Q 359 1031 393 1068 
+Q 428 1106 481 1106 
+L 4500 1106 
+Q 4547 1106 4581 1068 
+Q 4616 1031 4616 978 
+Q 4616 931 4581 890 
+Q 4547 850 4500 850 
+L 481 850 
+z
+M 481 2094 
+Q 428 2094 393 2131 
+Q 359 2169 359 2222 
+Q 359 2269 393 2309 
+Q 428 2350 481 2350 
+L 4500 2350 
+Q 4547 2350 4581 2309 
+Q 4616 2269 4616 2222 
+Q 4616 2169 4581 2131 
+Q 4547 2094 4500 2094 
+L 481 2094 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-72" d="M 372 0 
+Q 216 19 191 178 
+L 191 238 
+Q 216 397 372 416 
+L 966 416 
+L 966 2344 
+L 372 2344 
+Q 216 2363 191 2522 
+L 191 2578 
+Q 216 2741 372 2759 
+L 1253 2759 
+Q 1331 2750 1378 2703 
+Q 1425 2656 1434 2578 
+L 1434 2297 
+Q 1563 2447 1736 2562 
+Q 1909 2678 2112 2737 
+Q 2316 2797 2516 2797 
+Q 2750 2797 2933 2700 
+Q 3116 2603 3116 2394 
+Q 3116 2272 3037 2186 
+Q 2959 2100 2834 2100 
+Q 2719 2100 2636 2179 
+Q 2553 2259 2553 2381 
+L 2509 2381 
+Q 2203 2381 1956 2215 
+Q 1709 2050 1571 1776 
+Q 1434 1503 1434 1203 
+L 1434 416 
+L 2228 416 
+Q 2388 394 2406 238 
+L 2406 178 
+Q 2388 22 2228 0 
+L 372 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-69" d="M 488 178 
+L 488 238 
+Q 506 397 666 416 
+L 1522 416 
+L 1522 2344 
+L 716 2344 
+Q 556 2366 538 2522 
+L 538 2578 
+Q 547 2653 595 2701 
+Q 644 2750 716 2759 
+L 1813 2759 
+Q 1888 2750 1934 2703 
+Q 1981 2656 1991 2578 
+L 1991 416 
+L 2747 416 
+Q 2897 397 2925 238 
+L 2925 178 
+Q 2897 19 2747 0 
+L 666 0 
+Q 506 19 488 178 
+z
+M 1325 3584 
+Q 1325 3722 1422 3819 
+Q 1519 3916 1656 3916 
+Q 1797 3916 1894 3819 
+Q 1991 3722 1991 3584 
+Q 1991 3450 1891 3350 
+Q 1791 3250 1656 3250 
+Q 1525 3250 1425 3350 
+Q 1325 3450 1325 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-67" d="M 184 -525 
+Q 184 -281 311 -70 
+Q 438 141 647 275 
+Q 566 381 530 493 
+Q 494 606 494 728 
+Q 494 956 622 1166 
+Q 422 1434 422 1766 
+Q 422 2044 572 2283 
+Q 722 2522 967 2659 
+Q 1213 2797 1491 2797 
+Q 1853 2797 2106 2613 
+Q 2256 2719 2434 2773 
+Q 2613 2828 2797 2828 
+Q 2975 2828 3115 2729 
+Q 3256 2631 3256 2463 
+Q 3256 2350 3178 2272 
+Q 3100 2194 2994 2194 
+Q 2791 2194 2731 2413 
+Q 2581 2413 2394 2316 
+Q 2559 2066 2559 1766 
+Q 2559 1556 2471 1364 
+Q 2384 1172 2239 1036 
+Q 2094 900 1895 819 
+Q 1697 738 1491 738 
+Q 1188 738 922 897 
+Q 891 797 891 722 
+Q 891 622 939 536 
+Q 988 450 1081 416 
+Q 1100 419 1115 420 
+Q 1131 422 1153 422 
+Q 1166 422 1183 417 
+Q 1200 413 1215 408 
+Q 1231 403 1241 403 
+L 1691 403 
+Q 2072 403 2397 334 
+Q 2722 266 2945 61 
+Q 3169 -144 3169 -525 
+Q 3169 -766 3026 -947 
+Q 2884 -1128 2651 -1243 
+Q 2419 -1359 2162 -1412 
+Q 1906 -1466 1678 -1466 
+Q 1450 -1466 1195 -1412 
+Q 941 -1359 706 -1243 
+Q 472 -1128 328 -947 
+Q 184 -766 184 -525 
+z
+M 581 -525 
+Q 581 -706 775 -825 
+Q 969 -944 1230 -1000 
+Q 1491 -1056 1678 -1056 
+Q 1859 -1056 2123 -1000 
+Q 2388 -944 2580 -825 
+Q 2772 -706 2772 -525 
+Q 2772 -175 2450 -81 
+Q 2128 13 1663 13 
+L 1178 13 
+Q 941 13 761 -142 
+Q 581 -297 581 -525 
+z
+M 1491 1147 
+Q 1659 1147 1795 1231 
+Q 1931 1316 2012 1456 
+Q 2094 1597 2094 1766 
+Q 2094 1931 2014 2073 
+Q 1934 2216 1795 2302 
+Q 1656 2388 1491 2388 
+Q 1244 2388 1067 2200 
+Q 891 2013 891 1766 
+Q 891 1522 1067 1334 
+Q 1244 1147 1491 1147 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-68" d="M 63 178 
+L 63 238 
+Q 88 397 244 416 
+L 609 416 
+L 609 3494 
+L 244 3494 
+Q 88 3513 63 3675 
+L 63 3731 
+Q 88 3891 244 3909 
+L 897 3909 
+Q 1056 3891 1075 3731 
+L 1075 2472 
+Q 1241 2628 1459 2712 
+Q 1678 2797 1913 2797 
+Q 2334 2797 2540 2548 
+Q 2747 2300 2747 1869 
+L 2747 416 
+L 3109 416 
+Q 3188 406 3234 362 
+Q 3281 319 3291 238 
+L 3291 178 
+Q 3281 103 3234 56 
+Q 3188 9 3109 0 
+L 1972 0 
+Q 1816 19 1791 178 
+L 1791 238 
+Q 1816 397 1972 416 
+L 2278 416 
+L 2278 1844 
+Q 2278 2113 2198 2247 
+Q 2119 2381 1869 2381 
+Q 1656 2381 1470 2268 
+Q 1284 2156 1179 1968 
+Q 1075 1781 1075 1563 
+L 1075 416 
+L 1441 416 
+Q 1600 397 1619 238 
+L 1619 178 
+Q 1600 19 1441 0 
+L 244 0 
+Q 88 19 63 178 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-6e" d="M 63 178 
+L 63 238 
+Q 88 397 244 416 
+L 609 416 
+L 609 2344 
+L 244 2344 
+Q 88 2363 63 2522 
+L 63 2578 
+Q 88 2741 244 2759 
+L 897 2759 
+Q 972 2750 1019 2703 
+Q 1066 2656 1075 2578 
+L 1075 2472 
+Q 1241 2628 1459 2712 
+Q 1678 2797 1913 2797 
+Q 2334 2797 2540 2548 
+Q 2747 2300 2747 1869 
+L 2747 416 
+L 3109 416 
+Q 3188 406 3234 362 
+Q 3281 319 3291 238 
+L 3291 178 
+Q 3281 103 3234 56 
+Q 3188 9 3109 0 
+L 1972 0 
+Q 1816 19 1791 178 
+L 1791 238 
+Q 1816 397 1972 416 
+L 2278 416 
+L 2278 1844 
+Q 2278 2113 2198 2247 
+Q 2119 2381 1869 2381 
+Q 1656 2381 1470 2268 
+Q 1284 2156 1179 1968 
+Q 1075 1781 1075 1563 
+L 1075 416 
+L 1441 416 
+Q 1600 397 1619 238 
+L 1619 178 
+Q 1600 19 1441 0 
+L 244 0 
+Q 88 19 63 178 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(532.724609 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = top\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(298.436 90.546) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmtt10-79" d="M 275 -916 
+Q 275 -788 361 -708 
+Q 447 -628 569 -628 
+Q 691 -628 773 -708 
+Q 856 -788 856 -916 
+L 744 -916 
+Q 744 -1044 800 -1044 
+Q 1006 -1044 1154 -887 
+Q 1303 -731 1381 -506 
+L 1550 0 
+L 634 2344 
+L 347 2344 
+Q 194 2363 166 2522 
+L 166 2578 
+Q 178 2653 226 2701 
+Q 275 2750 347 2759 
+L 1281 2759 
+Q 1356 2750 1403 2703 
+Q 1450 2656 1459 2578 
+L 1459 2522 
+Q 1441 2363 1281 2344 
+L 1044 2344 
+Q 1275 1747 1386 1459 
+Q 1497 1172 1619 840 
+Q 1741 509 1741 469 
+Q 1744 500 1837 801 
+Q 1931 1103 2053 1473 
+Q 2175 1844 2344 2344 
+L 2088 2344 
+Q 1925 2363 1906 2522 
+L 1906 2578 
+Q 1925 2741 2088 2759 
+L 3022 2759 
+Q 3094 2750 3142 2701 
+Q 3191 2653 3200 2578 
+L 3200 2522 
+Q 3181 2366 3022 2344 
+L 2747 2344 
+L 1784 -506 
+Q 1653 -897 1403 -1178 
+Q 1153 -1459 800 -1459 
+Q 659 -1459 536 -1382 
+Q 413 -1306 344 -1181 
+Q 275 -1056 275 -916 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-6f" d="M 1678 -38 
+Q 1306 -38 1003 157 
+Q 700 353 526 684 
+Q 353 1016 353 1381 
+Q 353 1750 523 2079 
+Q 694 2409 1000 2612 
+Q 1306 2816 1678 2816 
+Q 1963 2816 2209 2697 
+Q 2456 2578 2629 2381 
+Q 2803 2184 2903 1918 
+Q 3003 1653 3003 1381 
+Q 3003 1016 2829 686 
+Q 2656 356 2351 159 
+Q 2047 -38 1678 -38 
+z
+M 1678 378 
+Q 2063 378 2298 708 
+Q 2534 1038 2534 1434 
+Q 2534 1678 2425 1900 
+Q 2316 2122 2122 2261 
+Q 1928 2400 1678 2400 
+Q 1431 2400 1236 2262 
+Q 1041 2125 930 1901 
+Q 819 1678 819 1434 
+Q 819 1038 1056 708 
+Q 1294 378 1678 378 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-70" d="M 63 -1241 
+L 63 -1184 
+Q 88 -1025 244 -1006 
+L 609 -1006 
+L 609 2344 
+L 244 2344 
+Q 88 2363 63 2522 
+L 63 2578 
+Q 88 2741 244 2759 
+L 897 2759 
+Q 972 2750 1019 2703 
+Q 1066 2656 1075 2578 
+L 1075 2497 
+Q 1428 2797 1888 2797 
+Q 2247 2797 2534 2594 
+Q 2822 2391 2980 2064 
+Q 3138 1738 3138 1381 
+Q 3138 1016 2964 686 
+Q 2791 356 2486 159 
+Q 2181 -38 1813 -38 
+Q 1403 -38 1075 275 
+L 1075 -1006 
+L 1441 -1006 
+Q 1600 -1025 1619 -1184 
+L 1619 -1241 
+Q 1600 -1403 1441 -1422 
+L 244 -1422 
+Q 88 -1403 63 -1241 
+z
+M 1778 378 
+Q 2034 378 2239 522 
+Q 2444 666 2556 900 
+Q 2669 1134 2669 1381 
+Q 2669 1616 2567 1850 
+Q 2466 2084 2278 2232 
+Q 2091 2381 1844 2381 
+Q 1675 2381 1514 2307 
+Q 1353 2234 1237 2100 
+Q 1122 1966 1075 1797 
+L 1075 1119 
+Q 1141 819 1319 598 
+Q 1497 378 1778 378 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 64.797) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = left\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 77.7915) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmtt10-6c" d="M 359 178 
+L 359 238 
+Q 378 397 538 416 
+L 1447 416 
+L 1447 3494 
+L 538 3494 
+Q 378 3513 359 3675 
+L 359 3731 
+Q 378 3891 538 3909 
+L 1734 3909 
+Q 1894 3891 1913 3731 
+L 1913 416 
+L 2822 416 
+Q 2978 397 3003 238 
+L 3003 178 
+Q 2978 19 2822 0 
+L 538 0 
+Q 378 19 359 178 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-66" d="M 256 178 
+L 256 238 
+Q 284 397 434 416 
+L 1166 416 
+L 1166 2344 
+L 453 2344 
+Q 294 2363 275 2522 
+L 275 2578 
+Q 284 2656 331 2703 
+Q 378 2750 453 2759 
+L 1166 2759 
+L 1166 3144 
+Q 1166 3381 1317 3567 
+Q 1469 3753 1703 3851 
+Q 1938 3950 2175 3950 
+Q 2419 3950 2608 3861 
+Q 2797 3772 2797 3559 
+Q 2797 3434 2717 3345 
+Q 2638 3256 2516 3256 
+Q 2406 3256 2317 3337 
+Q 2228 3419 2228 3531 
+L 2131 3531 
+Q 1934 3531 1782 3415 
+Q 1631 3300 1631 3116 
+L 1631 2759 
+L 2478 2759 
+Q 2553 2750 2600 2703 
+Q 2647 2656 2656 2578 
+L 2656 2522 
+Q 2638 2363 2478 2344 
+L 1631 2344 
+L 1631 416 
+L 2363 416 
+Q 2513 397 2541 238 
+L 2541 178 
+Q 2513 19 2363 0 
+L 434 0 
+Q 288 19 256 178 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(375.253906 0.28125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(427.744141 0.28125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(480.234375 0.28125)"/>
+    </g>
+    <!-- $\mathtt{y = top\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 90.11475) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 231.73845) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = left\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 244.73295) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(375.253906 0.28125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(427.744141 0.28125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(480.234375 0.28125)"/>
+    </g>
+    <!-- $\mathtt{y = bottom\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 257.0562) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmtt10-62" d="M 609 178 
+L 609 3494 
+L 244 3494 
+Q 88 3513 63 3675 
+L 63 3731 
+Q 88 3891 244 3909 
+L 897 3909 
+Q 1056 3891 1075 3731 
+L 1075 2497 
+Q 1428 2797 1888 2797 
+Q 2247 2797 2534 2594 
+Q 2822 2391 2980 2064 
+Q 3138 1738 3138 1381 
+Q 3138 1016 2964 686 
+Q 2791 356 2486 159 
+Q 2181 -38 1813 -38 
+Q 1403 -38 1075 275 
+L 1075 178 
+Q 1066 103 1019 56 
+Q 972 9 897 0 
+L 788 0 
+Q 628 19 609 178 
+z
+M 1778 378 
+Q 2034 378 2239 522 
+Q 2444 666 2556 900 
+Q 2669 1134 2669 1381 
+Q 2669 1616 2567 1850 
+Q 2466 2084 2278 2232 
+Q 2091 2381 1844 2381 
+Q 1675 2381 1514 2307 
+Q 1353 2234 1237 2100 
+Q 1122 1966 1075 1797 
+L 1075 1119 
+Q 1141 819 1319 598 
+Q 1497 378 1778 378 
+z
+" transform="scale(0.015625)"/>
+      <path id="Cmtt10-6d" d="M -38 178 
+L -38 238 
+Q -9 397 141 416 
+L 325 416 
+L 325 2344 
+L 141 2344 
+Q -9 2363 -38 2522 
+L -38 2578 
+Q -9 2741 141 2759 
+L 531 2759 
+Q 613 2750 661 2695 
+Q 709 2641 709 2566 
+Q 966 2797 1294 2797 
+Q 1447 2797 1578 2706 
+Q 1709 2616 1778 2463 
+Q 2053 2797 2450 2797 
+Q 3028 2797 3028 1869 
+L 3028 416 
+L 3213 416 
+Q 3363 397 3391 238 
+L 3391 178 
+Q 3359 19 3213 0 
+L 2528 0 
+Q 2369 22 2350 178 
+L 2350 238 
+Q 2369 394 2528 416 
+L 2644 416 
+L 2644 1844 
+Q 2644 2381 2413 2381 
+Q 2225 2381 2103 2251 
+Q 1981 2122 1925 1934 
+Q 1869 1747 1869 1563 
+L 1869 416 
+L 2053 416 
+Q 2206 397 2234 238 
+L 2234 178 
+Q 2203 19 2053 0 
+L 1369 0 
+Q 1209 22 1191 178 
+L 1191 238 
+Q 1209 394 1369 416 
+L 1484 416 
+L 1484 1844 
+Q 1484 2381 1253 2381 
+Q 1066 2381 944 2251 
+Q 822 2122 765 1934 
+Q 709 1747 709 1563 
+L 709 416 
+L 897 416 
+Q 1047 397 1075 238 
+L 1075 178 
+Q 1047 19 897 0 
+L 141 0 
+Q -6 19 -38 178 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(296.396 231.3072) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(285.836 244.3017) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(532.724609 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = bottom\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(279.596 257.0562) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(306.44 16.2) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right}$ -->
+    <g style="fill: #1a1a1a" transform="translate(314.84 29.1945) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = top\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(302.24 41.949) scale(0.12 -0.12)">
+     <defs>
+      <path id="Cmtt10-75" d="M 609 691 
+L 609 2344 
+L 244 2344 
+Q 88 2363 63 2522 
+L 63 2578 
+Q 88 2741 244 2759 
+L 897 2759 
+Q 972 2750 1019 2703 
+Q 1066 2656 1075 2578 
+L 1075 716 
+Q 1075 500 1211 439 
+Q 1347 378 1588 378 
+Q 1756 378 1917 447 
+Q 2078 516 2178 647 
+Q 2278 778 2278 947 
+L 2278 2344 
+L 1913 2344 
+Q 1753 2363 1734 2522 
+L 1734 2578 
+Q 1744 2656 1791 2703 
+Q 1838 2750 1913 2759 
+L 2566 2759 
+Q 2722 2741 2747 2578 
+L 2747 416 
+L 3109 416 
+Q 3188 406 3234 362 
+Q 3281 319 3291 238 
+L 3291 178 
+Q 3281 103 3234 56 
+Q 3188 9 3109 0 
+L 2456 0 
+Q 2384 9 2331 65 
+Q 2278 122 2278 191 
+Q 2122 78 1931 20 
+Q 1741 -38 1544 -38 
+Q 1131 -38 870 129 
+Q 609 297 609 691 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.578125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.578125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.578125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.578125)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.578125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.578125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.578125)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(427.744141 0.578125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(480.234375 0.578125)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 16.63125) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = left}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 29.62575) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+    </g>
+    <!-- $\mathtt{y = top\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 41.949) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.578125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.578125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.578125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.578125)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.578125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.578125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.578125)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(427.744141 0.578125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(480.234375 0.578125)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 64.797) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 77.7915) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(585.214844 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = top\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 90.546) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 231.3072) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 244.3017) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(585.214844 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = bottom\_in}$ -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 257.0562) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(306.44 302.0802) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = right}$ -->
+    <g style="fill: #1a1a1a" transform="translate(314.84 315.0747) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+    </g>
+    <!-- $\mathtt{y = bottom\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(283.28 327.8292) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.921875)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.921875)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.921875)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.921875)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(532.724609 0.921875)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(585.214844 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(637.705078 0.921875)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- $\mathtt{add\_text()}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 302.0802) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-61"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
+     <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(157.470703 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(209.960938 0)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(262.451172 0)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(314.941406 0)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(367.431641 0)"/>
+     <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
+     <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
+    </g>
+    <!-- $\mathtt{x = left}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 315.0747) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+    </g>
+    <!-- $\mathtt{y = bottom\_out}$ -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 327.39795) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.921875)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.921875)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.921875)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.921875)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.921875)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(532.724609 0.921875)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(585.214844 0.921875)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(637.705078 0.921875)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/docs/img/add_text_example.svg
+++ b/docs/img/add_text_example.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="456.656pt" height="337.7892pt" viewBox="0 0 456.656 337.7892" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="465.656pt" height="338.7072pt" viewBox="0 0 465.656 338.7072" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -18,40 +18,40 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 337.7892 
-L 456.656 337.7892 
-L 456.656 0 
+   <path d="M 0 338.7072 
+L 465.656 338.7072 
+L 465.656 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 31.4 268.6866 
-L 366.2 268.6866 
-L 366.2 46.9266 
-L 31.4 46.9266 
+    <path d="M 31.4 269.1456 
+L 366.2 269.1456 
+L 366.2 47.3856 
+L 31.4 47.3856 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 31.4 268.6866 
-L 31.4 46.9266 
+    <path d="M 31.4 269.1456 
+L 31.4 47.3856 
 " style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 366.2 268.6866 
-L 366.2 46.9266 
+    <path d="M 366.2 269.1456 
+L 366.2 47.3856 
 " style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 31.4 268.6866 
-L 366.2 268.6866 
+    <path d="M 31.4 269.1456 
+L 366.2 269.1456 
 " style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 31.4 46.9266 
-L 366.2 46.9266 
+    <path d="M 31.4 47.3856 
+L 366.2 47.3856 
 " style="fill: none; stroke: #000000; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="matplotlib.axis_1">
@@ -63,12 +63,12 @@ L 0 -6
 " style="stroke: #1a1a1a; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="31.4" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="31.4" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{0.0}$ -->
-      <g style="fill: #1a1a1a" transform="translate(21.8 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(21.8 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-30" d="M 2944 2048 
 C 2944 2560 2912 3072 2688 3546 
@@ -108,12 +108,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="98.36" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="98.36" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{0.2}$ -->
-      <g style="fill: #1a1a1a" transform="translate(88.76 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(88.76 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-32" d="M 2874 1114 
 L 2714 1114 
@@ -147,12 +147,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="165.32" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="165.32" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- $\mathdefault{0.4}$ -->
-      <g style="fill: #1a1a1a" transform="translate(155.72 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(155.72 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-34" d="M 3014 1056 
 L 3014 1254 
@@ -191,12 +191,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="232.28" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="232.28" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- $\mathdefault{0.6}$ -->
-      <g style="fill: #1a1a1a" transform="translate(222.68 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(222.68 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-36" d="M 2925 1306 
 C 2925 2118 2355 2733 1645 2733 
@@ -232,12 +232,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="299.24" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="299.24" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- $\mathdefault{0.8}$ -->
-      <g style="fill: #1a1a1a" transform="translate(289.64 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(289.64 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-38" d="M 2925 1075 
 C 2925 1306 2854 1594 2611 1862 
@@ -276,12 +276,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8dec1b3d1d" x="366.2" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#m8dec1b3d1d" x="366.2" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- $\mathdefault{1.0}$ -->
-      <g style="fill: #1a1a1a" transform="translate(356.6 287.097537) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(356.6 287.556537) scale(0.15 -0.15)">
        <defs>
         <path id="LatinModernMath-Regular-31" d="M 2682 0 
 L 2682 198 
@@ -315,105 +315,105 @@ L 0 -3
 " style="stroke: #1a1a1a; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m131efc0c90" x="48.14" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="48.14" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m131efc0c90" x="64.88" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="64.88" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m131efc0c90" x="81.62" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="81.62" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m131efc0c90" x="115.1" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="115.1" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m131efc0c90" x="131.84" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="131.84" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m131efc0c90" x="148.58" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="148.58" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m131efc0c90" x="182.06" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="182.06" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m131efc0c90" x="198.8" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="198.8" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m131efc0c90" x="215.54" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="215.54" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m131efc0c90" x="249.02" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="249.02" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m131efc0c90" x="265.76" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="265.76" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m131efc0c90" x="282.5" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="282.5" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m131efc0c90" x="315.98" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="315.98" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m131efc0c90" x="332.72" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="332.72" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m131efc0c90" x="349.46" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m131efc0c90" x="349.46" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -427,12 +427,12 @@ L 6 0
 " style="stroke: #1a1a1a; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="268.6866" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="269.1456" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- $\mathdefault{0.0}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 273.892069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 274.351069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
@@ -442,12 +442,12 @@ L 6 0
     <g id="ytick_2">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="224.3346" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="224.7936" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{0.2}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 229.540069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 229.999069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-32" transform="translate(77.799973 0.40625)"/>
@@ -457,12 +457,12 @@ L 6 0
     <g id="ytick_3">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="179.9826" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="180.4416" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{0.4}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 185.188069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 185.647069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.296875)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.296875)"/>
        <use xlink:href="#LatinModernMath-Regular-34" transform="translate(77.799973 0.296875)"/>
@@ -472,12 +472,12 @@ L 6 0
     <g id="ytick_4">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="135.6306" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="136.0896" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{0.6}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 140.836069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 141.295069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-36" transform="translate(77.799973 0.40625)"/>
@@ -487,12 +487,12 @@ L 6 0
     <g id="ytick_5">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="91.2786" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="91.7376" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{0.8}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 96.484069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 96.943069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(0 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-38" transform="translate(77.799973 0.40625)"/>
@@ -502,12 +502,12 @@ L 6 0
     <g id="ytick_6">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc947610920" x="31.4" y="46.9266" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+       <use xlink:href="#mc947610920" x="31.4" y="47.3856" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- $\mathdefault{1.0}$ -->
-      <g style="fill: #1a1a1a" transform="translate(7.2 52.132069) scale(0.15 -0.15)">
+      <g style="fill: #1a1a1a" transform="translate(7.2 52.591069) scale(0.15 -0.15)">
        <use xlink:href="#LatinModernMath-Regular-31" transform="translate(0 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(49.999985 0.40625)"/>
        <use xlink:href="#LatinModernMath-Regular-30" transform="translate(77.799973 0.40625)"/>
@@ -522,112 +522,112 @@ L 3 0
 " style="stroke: #1a1a1a; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="257.5986" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="258.0576" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="246.5106" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="246.9696" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="235.4226" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="235.8816" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="213.2466" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="213.7056" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="202.1586" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="202.6176" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="191.0706" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="191.5296" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="168.8946" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="169.3536" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="157.8066" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="158.2656" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="146.7186" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="147.1776" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="124.5426" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="125.0016" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="113.4546" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="113.9136" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="102.3666" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="102.8256" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="80.1906" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="80.6496" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="69.1026" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="69.5616" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m5f9d1e6504" x="31.4" y="58.0146" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
+       <use xlink:href="#m5f9d1e6504" x="31.4" y="58.4736" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
    </g>
    <g id="text_13">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(296.396 64.797) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(296.396 65.256) scale(0.12 -0.12)">
      <defs>
       <path id="Cmtt10-61" d="M 341 850 
 Q 341 1213 672 1423 
@@ -916,8 +916,8 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(285.836 77.7915) scale(0.12 -0.12)">
+    <!-- $\mathtt{x = }$"$\mathtt{right\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(276.836 78.48) scale(0.12 -0.12)">
      <defs>
       <path id="Cmr10-3d" d="M 481 850 
 Q 428 850 393 890 
@@ -942,6 +942,21 @@ Q 4616 2269 4616 2222
 Q 4616 2169 4581 2131 
 Q 4547 2094 4500 2094 
 L 481 2094 
+z
+" transform="scale(0.015625)"/>
+      <path id="LatinModernMath-Regular-22" d="M 1114 4288 
+C 1126 4416 1018 4512 890 4512 
+C 762 4512 653 4416 666 4288 
+L 806 2707 
+L 973 2707 
+L 1114 4288 
+z
+M 1728 4288 
+C 1741 4416 1632 4512 1504 4512 
+C 1376 4512 1267 4416 1280 4288 
+L 1421 2707 
+L 1587 2707 
+L 1728 4288 
 z
 " transform="scale(0.015625)"/>
       <path id="Cmtt10-72" d="M 372 0 
@@ -1171,19 +1186,21 @@ Q 88 19 63 178
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(532.724609 0.8125)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(622.614838 0.5)"/>
     </g>
-    <!-- $\mathtt{y = top\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(298.436 90.546) scale(0.12 -0.12)">
+    <!-- $\mathtt{y = }$"$\mathtt{top\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(289.436 91.464) scale(0.12 -0.12)">
      <defs>
       <path id="Cmtt10-79" d="M 275 -916 
 Q 275 -788 361 -708 
@@ -1304,19 +1321,21 @@ Q 1497 378 1778 378
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(517.634369 0.5)"/>
     </g>
    </g>
    <g id="text_14">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 64.797) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(44.792 65.256) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1328,8 +1347,8 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = left\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 77.7915) scale(0.12 -0.12)">
+    <!-- $\mathtt{x = }$"$\mathtt{left\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 78.2505) scale(0.12 -0.12)">
      <defs>
       <path id="Cmtt10-6c" d="M 359 178 
 L 359 238 
@@ -1392,31 +1411,35 @@ Q 288 19 256 178
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
-     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
-     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
-     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(375.253906 0.28125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(427.744141 0.28125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(480.234375 0.28125)"/>
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(570.124603 0.5)"/>
     </g>
-    <!-- $\mathtt{y = top\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 90.11475) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{top\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 90.80325) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(517.634369 0.5)"/>
     </g>
    </g>
    <g id="text_15">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 231.73845) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(44.792 231.96795) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1428,20 +1451,22 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = left\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 244.73295) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
-     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
-     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
-     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(375.253906 0.28125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(427.744141 0.28125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(480.234375 0.28125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{left\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 244.96245) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(570.124603 0.5)"/>
     </g>
-    <!-- $\mathtt{y = bottom\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(44.792 257.0562) scale(0.12 -0.12)">
+    <!-- $\mathtt{y = }$"$\mathtt{bottom\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(44.792 257.5152) scale(0.12 -0.12)">
      <defs>
       <path id="Cmtt10-62" d="M 609 178 
 L 609 3494 
@@ -1538,17 +1563,19 @@ Q -6 19 -38 178
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(675.105072 0.5)"/>
     </g>
    </g>
    <g id="text_16">
@@ -1565,32 +1592,36 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(285.836 244.3017) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(532.724609 0.8125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{right\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(276.836 244.5312) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(622.614838 0.5)"/>
     </g>
-    <!-- $\mathtt{y = bottom\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(279.596 257.0562) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{bottom\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(270.596 257.5152) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(675.105072 0.5)"/>
     </g>
    </g>
    <g id="text_17">
@@ -1607,18 +1638,20 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right}$ -->
-    <g style="fill: #1a1a1a" transform="translate(314.84 29.1945) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{right}$" -->
+    <g style="fill: #1a1a1a" transform="translate(305.84 29.424) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(465.144135 0.5)"/>
     </g>
-    <!-- $\mathtt{y = top\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(302.24 41.949) scale(0.12 -0.12)">
+    <!-- $\mathtt{y = }$"$\mathtt{top\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(293.24 42.408) scale(0.12 -0.12)">
      <defs>
       <path id="Cmtt10-75" d="M 609 691 
 L 609 2344 
@@ -1660,20 +1693,22 @@ Q 609 297 609 691
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.578125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.578125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.578125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.578125)"/>
-     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.578125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.578125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.578125)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(427.744141 0.578125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(480.234375 0.578125)"/>
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(570.124603 0.5)"/>
     </g>
    </g>
    <g id="text_18">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 16.63125) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(31.4 16.86075) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1685,31 +1720,35 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = left}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 29.62575) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
-     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
-     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
-     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{left}$" -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 29.85525) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(412.6539 0.5)"/>
     </g>
-    <!-- $\mathtt{y = top\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 41.949) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.578125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.578125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.578125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.578125)"/>
-     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.578125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.578125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.578125)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(427.744141 0.578125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(480.234375 0.578125)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{top\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 42.408) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(570.124603 0.5)"/>
     </g>
    </g>
    <g id="text_19">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(372.896 64.797) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(372.896 65.256) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1721,30 +1760,34 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(372.896 77.7915) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(532.724609 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(585.214844 0.8125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{right\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 78.48) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(675.105072 0.5)"/>
     </g>
-    <!-- $\mathtt{y = top\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(372.896 90.546) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-70" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(427.744141 0.8125)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{top\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 91.464) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-70" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(517.634369 0.5)"/>
     </g>
    </g>
    <g id="text_20">
@@ -1761,38 +1804,42 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(372.896 244.3017) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(532.724609 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(585.214844 0.8125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{right\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 244.5312) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(675.105072 0.5)"/>
     </g>
-    <!-- $\mathtt{y = bottom\_in}$ -->
-    <g style="fill: #1a1a1a" transform="translate(372.896 257.0562) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.8125)"/>
-     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.8125)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(532.724609 0.8125)"/>
-     <use xlink:href="#Cmtt10-6e" transform="translate(585.214844 0.8125)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{bottom\_in}$" -->
+    <g style="fill: #1a1a1a" transform="translate(372.896 257.5152) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-6e" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(675.105072 0.5)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(306.44 302.0802) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(306.44 302.5392) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1804,35 +1851,39 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = right}$ -->
-    <g style="fill: #1a1a1a" transform="translate(314.84 315.0747) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.8125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.8125)"/>
-     <use xlink:href="#Cmtt10-72" transform="translate(165.292969 0.8125)"/>
-     <use xlink:href="#Cmtt10-69" transform="translate(217.783203 0.8125)"/>
-     <use xlink:href="#Cmtt10-67" transform="translate(270.273438 0.8125)"/>
-     <use xlink:href="#Cmtt10-68" transform="translate(322.763672 0.8125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(375.253906 0.8125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{right}$" -->
+    <g style="fill: #1a1a1a" transform="translate(305.84 315.7632) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-72" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-69" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-67" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-68" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(465.144135 0.5)"/>
     </g>
-    <!-- $\mathtt{y = bottom\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(283.28 327.8292) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.921875)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.921875)"/>
-     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.921875)"/>
-     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.921875)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(532.724609 0.921875)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(585.214844 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(637.705078 0.921875)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{bottom\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(274.4 328.7472) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(675.105072 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(727.595306 0.5)"/>
     </g>
    </g>
    <g id="text_22">
     <!-- $\mathtt{add\_text()}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 302.0802) scale(0.12 -0.12)">
+    <g style="fill: #1a1a1a" transform="translate(31.4 302.5392) scale(0.12 -0.12)">
      <use xlink:href="#Cmtt10-61"/>
      <use xlink:href="#Cmtt10-64" transform="translate(52.490234 0)"/>
      <use xlink:href="#Cmtt10-64" transform="translate(104.980469 0)"/>
@@ -1844,29 +1895,33 @@ z
      <use xlink:href="#Cmr10-28" transform="translate(419.921875 0)"/>
      <use xlink:href="#Cmr10-29" transform="translate(458.740234 0)"/>
     </g>
-    <!-- $\mathtt{x = left}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 315.0747) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-78" transform="translate(0 0.28125)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.28125)"/>
-     <use xlink:href="#Cmtt10-6c" transform="translate(165.292969 0.28125)"/>
-     <use xlink:href="#Cmtt10-65" transform="translate(217.783203 0.28125)"/>
-     <use xlink:href="#Cmtt10-66" transform="translate(270.273438 0.28125)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.28125)"/>
+    <!-- $\mathtt{x = }$"$\mathtt{left}$" -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 315.5337) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-78" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-6c" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-65" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-66" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(412.6539 0.5)"/>
     </g>
-    <!-- $\mathtt{y = bottom\_out}$ -->
-    <g style="fill: #1a1a1a" transform="translate(31.4 327.39795) scale(0.12 -0.12)">
-     <use xlink:href="#Cmtt10-79" transform="translate(0 0.921875)"/>
-     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.921875)"/>
-     <use xlink:href="#Cmtt10-62" transform="translate(165.292969 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(217.783203 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(270.273438 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(322.763672 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(375.253906 0.921875)"/>
-     <use xlink:href="#Cmtt10-6d" transform="translate(427.744141 0.921875)"/>
-     <use xlink:href="#Cmtt10-5f" transform="translate(480.234375 0.921875)"/>
-     <use xlink:href="#Cmtt10-6f" transform="translate(532.724609 0.921875)"/>
-     <use xlink:href="#Cmtt10-75" transform="translate(585.214844 0.921875)"/>
-     <use xlink:href="#Cmtt10-74" transform="translate(637.705078 0.921875)"/>
+    <!-- $\mathtt{y = }$"$\mathtt{bottom\_out}$" -->
+    <g style="fill: #1a1a1a" transform="translate(31.4 328.08645) scale(0.12 -0.12)">
+     <use xlink:href="#Cmtt10-79" transform="translate(0 0.5)"/>
+     <use xlink:href="#Cmr10-3d" transform="translate(70.048828 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(165.292969 0.5)"/>
+     <use xlink:href="#Cmtt10-62" transform="translate(202.692963 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(255.183197 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(307.673431 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(360.163666 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(412.6539 0.5)"/>
+     <use xlink:href="#Cmtt10-6d" transform="translate(465.144135 0.5)"/>
+     <use xlink:href="#Cmtt10-5f" transform="translate(517.634369 0.5)"/>
+     <use xlink:href="#Cmtt10-6f" transform="translate(570.124603 0.5)"/>
+     <use xlink:href="#Cmtt10-75" transform="translate(622.614838 0.5)"/>
+     <use xlink:href="#Cmtt10-74" transform="translate(675.105072 0.5)"/>
+     <use xlink:href="#LatinModernMath-Regular-22" transform="translate(727.595306 0.5)"/>
     </g>
    </g>
   </g>

--- a/docs/usage/utilities.rst
+++ b/docs/usage/utilities.rst
@@ -7,7 +7,7 @@ Utility functions
 Add text
 ========
 
-:func:`add_text() <plothist.plothist_style.add_text>` is a useful function to add text to a plot. It allows you to easily position a text either to the left or right and at the top or bottom of your plot, thanks to aliases on the x and y parameters. Using them will ensure that your text stays aligned to the left or right of the sub-plot (= ax) you specify. The function is a wrapper around ``plt.text()``, so you can pass any parameter to it that you would pass to ``plt.text()`` like ``fontsize``, ``color``, ``fontweight``, etc.
+:func:`add_text() <plothist.plothist_style.add_text>` is a useful function to add text to a plot. It allows you to easily position a text either to the left or right and at the top or bottom of your plot, thanks to aliases on the ``x`` and ``y`` positional parameters. Using them ensures that your text stays aligned to the left or right of the sub-plot (= ax) you specify. The function is a wrapper around ``plt.text()``, so you can pass any parameter to it that you would pass to ``plt.text()`` like ``fontsize``, ``color``, ``fontweight``, etc.
 
 Here are the ``x`` and ``y`` aliases you can use, with their corresponding positions and alignment:
 
@@ -19,22 +19,22 @@ x aliases
 
    * - Alias
      - Value
-     - Default ha
-   * - ``left``
+     - Horizontal alignment (ha)
+   * - ``"left"``
      - 0.0
-     - ``left``
-   * - ``right``
+     - ``"left"``
+   * - ``"right"``
      - 1.0
-     - ``right``
-   * - ``left_in``
+     - ``"right"``
+   * - ``"left_in"``
      - 0.04
-     - ``left``
-   * - ``right_in``
+     - ``"left"``
+   * - ``"right_in"``
      - 0.97
-     - ``right``
-   * - ``right_out``
+     - ``"right"``
+   * - ``"right_out"``
      - 1.02
-     - ``right``
+     - ``"right"``
 
 y aliases
 ---------
@@ -44,19 +44,19 @@ y aliases
 
    * - Alias
      - Value
-     - Default va
-   * - ``top = top_out``
+     - Vertical alignment (va)
+   * - ``"top" = "top_out"``
      - 1.01
-     - ``bottom``
-   * - ``bottom = bottom_out``
+     - ``"bottom"``
+   * - ``"bottom" = "bottom_out"``
      - -0.11
-     - ``top``
-   * - ``top_in``
+     - ``"top"``
+   * - ``"top_in"``
      - 0.96
-     - ``bottom``
-   * - ``bottom_in``
+     - ``"bottom"``
+   * - ``"bottom_in"``
      - 0.04
-     - ``top``
+     - ``"top"``
 
 Here is an example of good combinations of aliases to add text to a plot:
 
@@ -64,7 +64,7 @@ Here is an example of good combinations of aliases to add text to a plot:
    :alt: Example of add_text
    :width: 500
 
-By default, the text also fit between the sub-plots by specifying the different axes, as shown in the example below:
+By default, the text also fits between the sub-plots by specifying the different axes, as shown in the example below:
 
 .. code-block:: python
 

--- a/docs/usage/utilities.rst
+++ b/docs/usage/utilities.rst
@@ -9,6 +9,69 @@ Add text
 
 :func:`add_text() <plothist.plothist_style.add_text>` is a useful function to add text to a plot. It allows you to easily position a text either to the left or right and at the top or bottom of your plot, thanks to aliases on the x and y parameters. Using them will ensure that your text stays aligned to the left or right of the sub-plot (= ax) you specify. The function is a wrapper around ``plt.text()``, so you can pass any parameter to it that you would pass to ``plt.text()`` like ``fontsize``, ``color``, ``fontweight``, etc.
 
+Here are the ``x`` and ``y`` aliases you can use, with their corresponding positions and alignement:
+
+X Values
+--------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Position
+     - Value
+     - Default ha
+   * - left
+     - 0.0
+     - left
+   * - right
+     - 1.0
+     - right
+   * - left_in
+     - 0.04
+     - left
+   * - right_in
+     - 0.97
+     - right
+   * - right_out
+     - 1.02
+     - right
+
+Y Values
+--------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Position
+     - Value
+     - Default va
+   * - top
+     - 1.01
+     - bottom
+   * - bottom
+     - -0.11
+     - top
+   * - top_out
+     - 1.01
+     - bottom
+   * - bottom_out
+     - -0.11
+     - top
+   * - top_in
+     - 0.96
+     - bottom
+   * - bottom_in
+     - 0.04
+     - top
+
+Here is an example of good combination of aliases to add text to a plot:
+
+.. image:: ../img/add_text_example.svg
+   :alt: Example of add_text
+   :width: 500
+
+By default, the text also fit between the sub-plots by specifying the different axes, as shown in the example below:
+
 .. code-block:: python
 
     from plothist import add_text

--- a/docs/usage/utilities.rst
+++ b/docs/usage/utilities.rst
@@ -9,62 +9,56 @@ Add text
 
 :func:`add_text() <plothist.plothist_style.add_text>` is a useful function to add text to a plot. It allows you to easily position a text either to the left or right and at the top or bottom of your plot, thanks to aliases on the x and y parameters. Using them will ensure that your text stays aligned to the left or right of the sub-plot (= ax) you specify. The function is a wrapper around ``plt.text()``, so you can pass any parameter to it that you would pass to ``plt.text()`` like ``fontsize``, ``color``, ``fontweight``, etc.
 
-Here are the ``x`` and ``y`` aliases you can use, with their corresponding positions and alignement:
+Here are the ``x`` and ``y`` aliases you can use, with their corresponding positions and alignment:
 
-X Values
---------
+x aliases
+---------
 
 .. list-table::
    :header-rows: 1
 
-   * - Position
+   * - Alias
      - Value
      - Default ha
-   * - left
+   * - ``left``
      - 0.0
-     - left
-   * - right
+     - ``left``
+   * - ``right``
      - 1.0
-     - right
-   * - left_in
+     - ``right``
+   * - ``left_in``
      - 0.04
-     - left
-   * - right_in
+     - ``left``
+   * - ``right_in``
      - 0.97
-     - right
-   * - right_out
+     - ``right``
+   * - ``right_out``
      - 1.02
-     - right
+     - ``right``
 
-Y Values
---------
+y aliases
+---------
 
 .. list-table::
    :header-rows: 1
 
-   * - Position
+   * - Alias
      - Value
      - Default va
-   * - top
+   * - ``top = top_out``
      - 1.01
-     - bottom
-   * - bottom
+     - ``bottom``
+   * - ``bottom = bottom_out``
      - -0.11
-     - top
-   * - top_out
-     - 1.01
-     - bottom
-   * - bottom_out
-     - -0.11
-     - top
-   * - top_in
+     - ``top``
+   * - ``top_in``
      - 0.96
-     - bottom
-   * - bottom_in
+     - ``bottom``
+   * - ``bottom_in``
      - 0.04
-     - top
+     - ``top``
 
-Here is an example of good combination of aliases to add text to a plot:
+Here is an example of good combinations of aliases to add text to a plot:
 
 .. image:: ../img/add_text_example.svg
    :alt: Example of add_text

--- a/src/plothist/plothist_style.py
+++ b/src/plothist/plothist_style.py
@@ -224,9 +224,9 @@ def add_text(
     text : str
         The text to add.
     x : float, optional
-        Horizontal position of the text in unit of the normalized x-axis length. The default is value "left", which is an alias for 0.0. The other alias "right" corresponds to 1.0.
+        Horizontal position of the text in unit of the normalized x-axis length. The default is value "left", which is an alias for 0.0. Other aliases are "right", "left_in", "right_in", "right_out".
     y : float, optional
-        Vertical position of the text in unit of the normalized y-axis length. The default is value "top", which is an alias for 1.01. The other alias "bottom" corresponds to 0.0.
+        Vertical position of the text in unit of the normalized y-axis length. The default is value "top", which is an alias for 1.01. Other aliases are "top_in", "bottom_in", "top_out"="top", "bottom_out"="bottom".
     fontsize : int, optional
         Font size, by default 12.
     white_background : bool, optional
@@ -235,32 +235,45 @@ def add_text(
         Figure axis, by default None.
     kwargs : dict
         Keyword arguments to be passed to the ax.text() function.
-        In particular, the keyword arguments ha and va, which are set to "left" (or "right" if x="right") and "bottom" by default, can be used to change the text alignment.
+        In particular, the keyword arguments ha and va, which are set by default to accommodate to the x and y aliases, can be used to change the text alignment.
 
     Returns
     -------
     None
     """
-    kwargs.setdefault("ha", "right" if x == "right" else "left")
-    kwargs.setdefault("va", "bottom")
+    kwargs.setdefault("ha", "right" if x in ["right", "right_in"] else "left")
+    kwargs.setdefault("va", "top" if y in ["top_in", "bottom", "bottom_out"] else "bottom")
 
     if ax is None:
         ax = plt.gca()
     transform = ax.transAxes
 
-    if x == "left":
-        x = 0.0
-    elif x == "right":
-        x = 1.0
-    elif type(x) not in [float, int]:
-        raise ValueError(f"x should be a float or 'left'/'right' ({x} given))")
+    x_values = {
+        "left": 0.0,
+        "right": 1.0,
+        "left_in": 0.04,
+        "right_in": 0.97,
+        "right_out": 1.02,
+    }
 
-    if y == "top":
-        y = 1.01
-    elif y == "bottom":
-        y = 0.0
-    elif type(y) not in [float, int]:
-        raise ValueError(f"y should be a float or 'top'/'bottom' ({y} given)")
+    y_values = {
+        "top": 1.01,
+        "bottom": -0.11,
+        "top_out": 1.01,
+        "bottom_out": -0.11,
+        "top_in": 0.96,
+        "bottom_in": 0.04,
+    }
+
+    if isinstance(x, str):
+        x = x_values.get(x)
+        if x is None:
+            raise ValueError(f"{x} not a float or a valid position")
+
+    if isinstance(y, str):
+        y = y_values.get(y)
+        if y is None:
+            raise ValueError(f"{y} not a float or a valid position")
 
     t = ax.text(
         x,

--- a/src/plothist/plothist_style.py
+++ b/src/plothist/plothist_style.py
@@ -311,9 +311,9 @@ def add_luminosity(
     collaboration : str
         Collaboration name.
     x : float, optional
-        Horizontal position of the text in unit of the normalized x-axis length. The default is value "right", which is an alias for 1.0.
+        Horizontal position of the text in unit of the normalized x-axis length. The default is value "right", which is an alias for 1.0. Can take other aliases such as "left", "left_in", "right_in", "right_out".
     y : float, optional
-        Vertical position of the text in unit of the normalized y-axis length. The default is value "top", which is an alias for 1.01.
+        Vertical position of the text in unit of the normalized y-axis length. The default is value "top", which is an alias for 1.01. Can take other aliases such as "top_in", "bottom_in", "top_out"="top", "bottom_out"="bottom".
     fontsize : int, optional
         Font size, by default 12.
     is_data : bool, optional

--- a/src/plothist/plothist_style.py
+++ b/src/plothist/plothist_style.py
@@ -237,6 +237,11 @@ def add_text(
         Keyword arguments to be passed to the ax.text() function.
         In particular, the keyword arguments ha and va, which are set by default to accommodate to the x and y aliases, can be used to change the text alignment.
 
+    Raises
+    ------
+    ValueError
+        If the x or y position is not a float or a valid position.
+
     Returns
     -------
     None

--- a/src/plothist/plothist_style.py
+++ b/src/plothist/plothist_style.py
@@ -242,7 +242,9 @@ def add_text(
     None
     """
     kwargs.setdefault("ha", "right" if x in ["right", "right_in"] else "left")
-    kwargs.setdefault("va", "top" if y in ["top_in", "bottom", "bottom_out"] else "bottom")
+    kwargs.setdefault(
+        "va", "top" if y in ["top_in", "bottom", "bottom_out"] else "bottom"
+    )
 
     if ax is None:
         ax = plt.gca()


### PR DESCRIPTION
Due to popular demand, more aliases have been added to the ``add_text`` function.
Only the ``bottom`` option is not retro-compatible, but it was really useless with its old value. `Left`, `right` and `top` values are the same as before.

Documentation to see the table correctly here: https://plothist.readthedocs.io/en/add_text_upgrade/usage/utilities.html#add-text