### PR TITLE
Add plot_only option in plot_data_model_comparison

### DIFF
--- a/src/plothist/plotters.py
+++ b/src/plothist/plotters.py
@@ -995,10 +995,10 @@ def plot_data_model_comparison(
     model_uncertainty=True,
     model_uncertainty_label="Model stat. unc.",
     data_uncertainty_type="asymmetrical",
-    plot_only=None,
     fig=None,
     ax_main=None,
     ax_comparison=None,
+    plot_only=None,
     **comparison_kwargs,
 ):
     """
@@ -1041,14 +1041,14 @@ def plot_data_model_comparison(
         The label for the model uncertainties. Default is "Model stat. unc.".
     data_uncertainty_type : str, optional
         What kind of bin uncertainty to use for data_hist: "symmetrical" for the Poisson standard deviation derived from the variance stored in the histogram object, "asymmetrical" for asymmetrical uncertainties based on a Poisson confidence interval. Default is "asymmetrical".
-    plot_only : str, optional
-        If "ax_main" or "ax_comparison", only the main or comparison axis is plotted on the figure. Both axes are plotted if None is specified, which is the default.
     fig : matplotlib.figure.Figure or None, optional
         The figure to use for the plot. If fig, ax_main and ax_comparison are None, a new figure will be created. Default is None.
     ax_main : matplotlib.axes.Axes or None, optional
         The main axes for the histogram comparison. If fig, ax_main and ax_comparison are None, a new axes will be created. Default is None.
     ax_comparison : matplotlib.axes.Axes or None, optional
         The axes for the comparison plot. If fig, ax_main and ax_comparison are None, a new axes will be created. Default is None.
+    plot_only : str, optional
+        If "ax_main" or "ax_comparison", only the main or comparison axis is plotted on the figure. Both axes are plotted if None is specified, which is the default. This can only be used when fig, ax_main and ax_comparison are not provided by the user.
     **comparison_kwargs : optional
         Arguments to be passed to plot_comparison(), including the choice of the comparison function and the treatment of the uncertainties (see documentation of plot_comparison() for details). If they are not provided explicitly, the following arguments are passed by default: h1_label="Data", h2_label="Pred.", comparison="split_ratio".
 
@@ -1087,10 +1087,10 @@ def plot_data_model_comparison(
             fig, (ax_main, ax_comparison) = create_comparison_figure()
         elif plot_only == "ax_main":
             fig, ax_main = plt.subplots()
-            fig_temp, ax_comparison = plt.subplots()
+            _, ax_comparison = plt.subplots()
         elif plot_only == "ax_comparison":
             fig, ax_comparison = plt.subplots()
-            fig_temp, ax_main = plt.subplots()
+            _, ax_main = plt.subplots()
         else:
             raise ValueError("plot_only must be 'ax_main', 'ax_comparison' or None.")
     elif fig is None or ax_main is None or ax_comparison is None:

--- a/src/plothist/plotters.py
+++ b/src/plothist/plotters.py
@@ -1042,7 +1042,7 @@ def plot_data_model_comparison(
     data_uncertainty_type : str, optional
         What kind of bin uncertainty to use for data_hist: "symmetrical" for the Poisson standard deviation derived from the variance stored in the histogram object, "asymmetrical" for asymmetrical uncertainties based on a Poisson confidence interval. Default is "asymmetrical".
     plot_only : str, optional
-        If "ax_main" or "ax_comparison", only the main ax or the comparison ax is plotted n the figure respectively. Both axes are plotted if None, which is the default value.
+        If "ax_main" or "ax_comparison", only the main or comparison axis is plotted on the figure. Both axes are plotted if None is specified, which is the default.
     fig : matplotlib.figure.Figure or None, optional
         The figure to use for the plot. If fig, ax_main and ax_comparison are None, a new figure will be created. Default is None.
     ax_main : matplotlib.axes.Axes or None, optional

--- a/src/plothist/plotters.py
+++ b/src/plothist/plotters.py
@@ -995,6 +995,7 @@ def plot_data_model_comparison(
     model_uncertainty=True,
     model_uncertainty_label="Model stat. unc.",
     data_uncertainty_type="asymmetrical",
+    plot_only=None,
     fig=None,
     ax_main=None,
     ax_comparison=None,
@@ -1040,6 +1041,8 @@ def plot_data_model_comparison(
         The label for the model uncertainties. Default is "Model stat. unc.".
     data_uncertainty_type : str, optional
         What kind of bin uncertainty to use for data_hist: "symmetrical" for the Poisson standard deviation derived from the variance stored in the histogram object, "asymmetrical" for asymmetrical uncertainties based on a Poisson confidence interval. Default is "asymmetrical".
+    plot_only : str, optional
+        If "ax_main" or "ax_comparison", only the main ax or the comparison ax is plotted n the figure respectively. Both axes are plotted if None, which is the default value.
     fig : matplotlib.figure.Figure or None, optional
         The figure to use for the plot. If fig, ax_main and ax_comparison are None, a new figure will be created. Default is None.
     ax_main : matplotlib.axes.Axes or None, optional
@@ -1080,11 +1083,25 @@ def plot_data_model_comparison(
             _check_counting_histogram(component)
 
     if fig is None and ax_main is None and ax_comparison is None:
-        fig, (ax_main, ax_comparison) = create_comparison_figure()
+        if plot_only is None:
+            fig, (ax_main, ax_comparison) = create_comparison_figure()
+        elif plot_only == "ax_main":
+            fig, ax_main = plt.subplots()
+            fig_temp, ax_comparison = plt.subplots()
+        elif plot_only == "ax_comparison":
+            fig, ax_comparison = plt.subplots()
+            fig_temp, ax_main = plt.subplots()
+        else:
+            raise ValueError("plot_only must be 'ax_main', 'ax_comparison' or None.")
     elif fig is None or ax_main is None or ax_comparison is None:
         raise ValueError(
             "Need to provide fig, ax_main and ax_comparison (or none of them)."
         )
+    else:
+        if plot_only is not None:
+            raise ValueError(
+                "Cannot provide fig, ax_main or ax_comparison with plot_only."
+            )
 
     plot_model(
         stacked_components=stacked_components,
@@ -1112,7 +1129,10 @@ def plot_data_model_comparison(
         label=data_label,
     )
 
-    _ = ax_main.xaxis.set_ticklabels([])
+    if plot_only == "ax_main":
+        ax_main.set_xlabel(xlabel)
+    else:
+        _ = ax_main.xaxis.set_ticklabels([])
 
     if model_type == "histograms":
         model_hist = sum(model_components)


### PR DESCRIPTION
Only getting the main or comparison ax from `plot_data_model_comparison()` is not that trivial. Copying/moving axes to other figures is impossible to do in matplotlib. To redo the axes, the user could redo the plot by calling `plot_model()` and `plot_error_hist()`, or copy/pasting what we do for functions for the comparison ax, but this solution is complicated and the plot is already here in `plot_data_model_comparison()`. The user could use `fig.delaxes()`, but he needs to put the ticks and label back for `ax_main`, and the `figzise` will still be the 2 axes one, resizing the `ax_comparison` to a standard size is messy.`

This proposition is a small quality of life improvement to give the user the possibility to only keep one of the two axes on the fig, and remove the other, that works cleanly.

![model_only_main](https://github.com/cyrraz/plothist/assets/43090327/709c334a-b265-45d4-a4f1-b4b560853a35)
![model_only_comp](https://github.com/cyrraz/plothist/assets/43090327/4662af49-e5c1-4423-a68d-4c95bcafa0ae)

