### PR TITLE
fix zenodo json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,6 @@
     "description": "Visualize and compare data in a scalable way and a beautiful style.",
     "license": "BSD 3-Clause License",
     "title": "plothist",
-    "version": "v1.2.4",
     "upload_type": "software",
     "creators": [
         {


### PR DESCRIPTION
Remove the version, as suggested by

```
import json
import requests
from jsonschema import validate, ValidationError

def load_json(file_path):
    with open(file_path, 'r') as file:
        return json.load(file)

def fetch_schema(url):
    response = requests.get(url)
    return response.json()

def validate_json(json_data, schema):
    try:
        validate(instance=json_data, schema=schema)
        print("JSON is valid against the schema.")
    except ValidationError as err:
        print("JSON is invalid. Error message:")
        print(err.message)

if __name__ == "__main__":
    json_file_path = 'plothist/.zenodo.json'
    schema_url = 'https://raw.githubusercontent.com/zenodo/zenodo/master/zenodo/modules/deposit/jsonschemas/deposits/records/legacyrecord.json'

    json_data = load_json(json_file_path)
    schema = fetch_schema(schema_url)

    validate_json(json_data, schema)
```