### PR TITLE
docs: add sphinx.ext.viewcode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.intersphinx",
 ]


### PR DESCRIPTION
This should create a "view code" button next to the functions in the docs.