### PR TITLE
fix version comparison when making examples, update precommit hooks, …

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,37 +3,35 @@ name: Python package
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flit pytest pre-commit
-        flit install
-    - name: Copy documentation
-      run: |
-        cp -r docs $LD_LIBRARY_PATH/python${{ matrix.python-version }}/site-packages/plothist/docs
-    - name: Run pre-commit
-      if: matrix.python-version != '3.7'
-      run: |
-        pre-commit run --all-files
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flit pytest pre-commit
+          flit install
+      - name: Copy documentation
+        run: |
+          cp -r docs $LD_LIBRARY_PATH/python${{ matrix.python-version }}/site-packages/plothist/docs
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _build/
 test/
 metadata.yaml
 temp_img/
+.venv
 
 # Ignore local readthedocs build
 html/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.16.0"
+    rev: "1.19.1"
     hooks:
       - id: blacken-docs
         args: ["--line-length", "120"]
@@ -8,7 +8,7 @@ repos:
         - black==24.2.0
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -24,12 +24,12 @@ repos:
         exclude: '.*\.svg$'
 
   - repo: https://github.com/psf/black
-    rev: "24.2.0"
+    rev: "25.1.0"
     hooks:
       - id: black
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
     - id: codespell
       additional_dependencies:

--- a/docs/basics/variable_registry.rst
+++ b/docs/basics/variable_registry.rst
@@ -148,7 +148,7 @@ This will add the new properties to the ``yaml`` file to all the variables in ``
 
 The same :func:`get_variable_from_registry() <plothist.variable_registry.get_variable_from_registry>` function can be used to get the new properties.
 
-To modify extisting properties, you have to call :func:`update_variable_registry() <plothist.variable_registry.update_variable_registry>` with the new properties and the ``overwrite`` parameter set to ``True``. It will overwrite the existing properties values with the new ones.
+To modify existing properties, you have to call :func:`update_variable_registry() <plothist.variable_registry.update_variable_registry>` with the new properties and the ``overwrite`` parameter set to ``True``. It will overwrite the existing properties values with the new ones.
 
 
 Remove parameters

--- a/docs/img/1d_comparison_advanced.svg
+++ b/docs/img/1d_comparison_advanced.svg
@@ -1853,18 +1853,18 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="254.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="287.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="343.399948"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="387.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="443.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="482.799927"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="510.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="549.499908"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(254.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(287.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(343.399948 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(387.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(443.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(482.799927 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(510.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(549.499908 0)"/>
      </g>
     </g>
    </g>
@@ -1968,12 +1968,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-54"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="111.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="161.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="189.199951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="244.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-41" x="277.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(111.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(161.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(189.199951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(244.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-41" transform="translate(277.999939 0)"/>
      </g>
     </g>
     <g id="patch_12">
@@ -2023,12 +2023,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-54"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="111.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="161.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="189.199951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="244.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-42" x="277.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(111.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(161.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(189.199951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(244.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-42" transform="translate(277.999939 0)"/>
      </g>
     </g>
     <g id="LineCollection_3">
@@ -2046,11 +2046,11 @@ L 83.883125 49.6575
      <!-- Test A -->
      <g style="fill: #1a1a1a" transform="translate(105.483125 59.8575) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-54"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="116.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="155.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="194.899963"/>
-      <use xlink:href="#LatinModernMath-Regular-41" x="228.09996"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(116.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(155.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(194.899963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-41" transform="translate(228.09996 0)"/>
      </g>
     </g>
     <g id="LineCollection_4">
@@ -2068,11 +2068,11 @@ L 83.883125 66.38625
      <!-- Test B -->
      <g style="fill: #1a1a1a" transform="translate(105.483125 76.58625) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-54"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="116.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="155.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="194.899963"/>
-      <use xlink:href="#LatinModernMath-Regular-42" x="228.09996"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(116.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(155.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(194.899963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-42" transform="translate(228.09996 0)"/>
      </g>
     </g>
    </g>
@@ -3112,20 +3112,20 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-56"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="74.999985"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="124.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="164.199966"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="191.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="241.999939"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="297.59993"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="325.399918"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="369.799911"/>
-      <use xlink:href="#LatinModernMath-Regular-5b" x="402.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="430.799896"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="486.399887"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="541.999878"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="569.799866"/>
-      <use xlink:href="#LatinModernMath-Regular-5d" x="608.69986"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(74.999985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(124.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(164.199966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(191.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(241.999939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(297.59993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(325.399918 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(369.799911 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5b" transform="translate(402.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(430.799896 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(486.399887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(541.999878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(569.799866 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5d" transform="translate(608.69986 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_asymmetry.svg
+++ b/docs/img/1d_comparison_asymmetry.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1516,15 +1516,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_difference.svg
+++ b/docs/img/1d_comparison_difference.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1177,48 +1177,48 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-43"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="72.199982"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="122.199966"/>
-     <use xlink:href="#LatinModernMath-Regular-70" x="205.499954"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="261.099945"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="311.09993"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="350.299927"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="378.099915"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="417.499908"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="467.499893"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="523.099884"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="556.299881"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="606.299866"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="636.899857"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="670.099854"/>
-     <use xlink:href="#LatinModernMath-Regular-77" x="708.999847"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="781.199829"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="831.199814"/>
-     <use xlink:href="#LatinModernMath-Regular-68" x="864.399811"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="919.999802"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="947.799789"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="987.199783"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="1026.099777"/>
-     <use xlink:href="#LatinModernMath-Regular-77" x="1059.299774"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="1131.499756"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="1159.299744"/>
-     <use xlink:href="#LatinModernMath-Regular-68" x="1198.199738"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="1253.799728"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="1286.999725"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="1342.599716"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="1370.399704"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="1400.999695"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="1431.599686"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="1475.99968"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="1515.199677"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="1559.59967"/>
-     <use xlink:href="#LatinModernMath-Regular-63" x="1615.199661"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="1659.599655"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="1703.999649"/>
-     <use xlink:href="#LatinModernMath-Regular-70" x="1737.199646"/>
-     <use xlink:href="#LatinModernMath-Regular-6c" x="1792.799637"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="1820.599625"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="1870.599609"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(72.199982 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(122.199966 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-70" transform="translate(205.499954 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(261.099945 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(311.09993 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(350.299927 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(378.099915 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(417.499908 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(467.499893 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(523.099884 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(556.299881 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(606.299866 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(636.899857 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(670.099854 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-77" transform="translate(708.999847 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(781.199829 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(831.199814 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-68" transform="translate(864.399811 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(919.999802 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(947.799789 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(987.199783 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(1026.099777 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-77" transform="translate(1059.299774 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(1131.499756 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(1159.299744 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-68" transform="translate(1198.199738 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(1253.799728 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(1286.999725 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(1342.599716 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1370.399704 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(1400.999695 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(1431.599686 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(1475.99968 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(1515.199677 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(1559.59967 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-63" transform="translate(1615.199661 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(1659.599655 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(1703.999649 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-70" transform="translate(1737.199646 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(1792.799637 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(1820.599625 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(1870.599609 0)"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1849,15 +1849,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -2063,18 +2063,18 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-44"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="76.399994"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="104.199982"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="134.799973"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="165.399963"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="209.799957"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="248.999954"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="293.399948"/>
-     <use xlink:href="#LatinModernMath-Regular-63" x="348.999939"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="393.399933"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="437.799927"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="470.999924"/>
-     <use xlink:href="#LatinModernMath-Regular-78" x="520.999908"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(76.399994 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(104.199982 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(134.799973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(165.399963 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(209.799957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(248.999954 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(293.399948 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-63" transform="translate(348.999939 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(393.399933 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(437.799927 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(470.999924 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-78" transform="translate(520.999908 0)"/>
     </g>
    </g>
   </g>

--- a/docs/img/1d_comparison_efficiency.svg
+++ b/docs/img/1d_comparison_efficiency.svg
@@ -1111,12 +1111,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2060,15 +2060,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -2205,15 +2205,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-66" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-66" x="98.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="129.299973"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="157.09996"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.499954"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.299942"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="273.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="329.299927"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="373.699921"/>
+      <use xlink:href="#LatinModernMath-Regular-66" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-66" transform="translate(98.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(129.299973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(157.09996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.499954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.299942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(273.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(329.299927 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(373.699921 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_only_efficiency.svg
+++ b/docs/img/1d_comparison_only_efficiency.svg
@@ -879,15 +879,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1318,15 +1318,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-66" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-66" x="98.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="129.299973"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="157.09996"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.499954"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.299942"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="273.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="329.299927"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="373.699921"/>
+      <use xlink:href="#LatinModernMath-Regular-66" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-66" transform="translate(98.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(129.299973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(157.09996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.499954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.299942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(273.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(329.299927 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(373.699921 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_pull.svg
+++ b/docs/img/1d_comparison_pull.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1505,15 +1505,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_ratio.svg
+++ b/docs/img/1d_comparison_ratio.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -948,7 +948,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-68"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="55.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(55.599991 0)"/>
      </g>
     </g>
     <g id="patch_10">
@@ -964,7 +964,7 @@ z
      <!-- h2 -->
      <g style="fill: #1a1a1a" transform="translate(375.42875 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-68"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="55.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(55.599991 0)"/>
      </g>
     </g>
    </g>
@@ -1508,15 +1508,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_relative_difference.svg
+++ b/docs/img/1d_comparison_relative_difference.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1571,15 +1571,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_comparison_split_ratio.svg
+++ b/docs/img/1d_comparison_split_ratio.svg
@@ -877,12 +877,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1030,7 +1030,7 @@ L 70.796 284.4
 L 70.796 232.827907 
 L 64.1 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 70.796 276.847442 
@@ -1038,7 +1038,7 @@ L 77.492 276.847442
 L 77.492 240.380465 
 L 70.796 240.380465 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 77.492 276.847442 
@@ -1046,7 +1046,7 @@ L 84.188 276.847442
 L 84.188 240.380465 
 L 77.492 240.380465 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 84.188 267.730698 
@@ -1054,7 +1054,7 @@ L 90.884 267.730698
 L 90.884 249.497209 
 L 84.188 249.497209 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 90.884 266.388739 
@@ -1062,7 +1062,7 @@ L 97.58 266.388739
 L 97.58 250.839168 
 L 90.884 250.839168 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 97.58 264.379889 
@@ -1070,7 +1070,7 @@ L 104.276 264.379889
 L 104.276 252.848018 
 L 97.58 252.848018 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 104.276 263.402302 
@@ -1078,7 +1078,7 @@ L 110.972 263.402302
 L 110.972 253.825605 
 L 104.276 253.825605 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 110.972 262.641057 
@@ -1086,7 +1086,7 @@ L 117.668 262.641057
 L 117.668 254.58685 
 L 110.972 254.58685 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 117.668 261.76422 
@@ -1094,7 +1094,7 @@ L 124.364 261.76422
 L 124.364 255.463687 
 L 117.668 255.463687 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 124.364 261.47907 
@@ -1102,7 +1102,7 @@ L 131.06 261.47907
 L 131.06 255.748837 
 L 124.364 255.748837 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 131.06 261.259546 
@@ -1110,7 +1110,7 @@ L 137.756 261.259546
 L 137.756 255.968361 
 L 131.06 255.968361 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 137.756 260.911157 
@@ -1118,7 +1118,7 @@ L 144.452 260.911157
 L 144.452 256.31675 
 L 137.756 256.31675 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 144.452 260.55765 
@@ -1126,7 +1126,7 @@ L 151.148 260.55765
 L 151.148 256.670257 
 L 144.452 256.670257 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 151.148 260.504678 
@@ -1134,7 +1134,7 @@ L 157.844 260.504678
 L 157.844 256.723229 
 L 151.148 256.723229 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 157.844 260.372547 
@@ -1142,7 +1142,7 @@ L 164.54 260.372547
 L 164.54 256.85536 
 L 157.844 256.85536 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 164.54 260.336856 
@@ -1150,7 +1150,7 @@ L 171.236 260.336856
 L 171.236 256.891051 
 L 164.54 256.891051 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 171.236 260.340715 
@@ -1158,7 +1158,7 @@ L 177.932 260.340715
 L 177.932 256.887192 
 L 171.236 256.887192 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 177.932 260.248078 
@@ -1166,7 +1166,7 @@ L 184.628 260.248078
 L 184.628 256.979829 
 L 177.932 256.979829 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 184.628 260.12039 
@@ -1174,7 +1174,7 @@ L 191.324 260.12039
 L 191.324 257.107517 
 L 184.628 257.107517 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 191.324 260.071467 
@@ -1182,7 +1182,7 @@ L 198.02 260.071467
 L 198.02 257.15644 
 L 191.324 257.15644 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 198.02 259.929842 
@@ -1190,7 +1190,7 @@ L 204.716 259.929842
 L 204.716 257.298065 
 L 198.02 257.298065 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 204.716 259.79338 
@@ -1198,7 +1198,7 @@ L 211.412 259.79338
 L 211.412 257.434527 
 L 204.716 257.434527 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 211.412 259.738279 
@@ -1206,7 +1206,7 @@ L 218.108 259.738279
 L 218.108 257.489628 
 L 211.412 257.489628 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 218.108 259.620729 
@@ -1214,7 +1214,7 @@ L 224.804 259.620729
 L 224.804 257.607178 
 L 218.108 257.607178 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 224.804 259.559316 
@@ -1222,7 +1222,7 @@ L 231.5 259.559316
 L 231.5 257.668591 
 L 224.804 257.668591 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 231.5 259.529066 
@@ -1230,7 +1230,7 @@ L 238.196 259.529066
 L 238.196 257.698841 
 L 231.5 257.698841 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 238.196 259.529643 
@@ -1238,7 +1238,7 @@ L 244.892 259.529643
 L 244.892 257.698264 
 L 238.196 257.698264 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 244.892 259.561867 
@@ -1246,7 +1246,7 @@ L 251.588 259.561867
 L 251.588 257.66604 
 L 244.892 257.66604 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 251.588 259.570963 
@@ -1254,7 +1254,7 @@ L 258.284 259.570963
 L 258.284 257.656944 
 L 251.588 257.656944 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 258.284 259.587879 
@@ -1262,7 +1262,7 @@ L 264.98 259.587879
 L 264.98 257.640028 
 L 258.284 257.640028 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 264.98 259.690242 
@@ -1270,7 +1270,7 @@ L 271.676 259.690242
 L 271.676 257.537665 
 L 264.98 257.537665 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 271.676 259.809753 
@@ -1278,7 +1278,7 @@ L 278.372 259.809753
 L 278.372 257.418154 
 L 271.676 257.418154 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 278.372 260.00022 
@@ -1286,7 +1286,7 @@ L 285.068 260.00022
 L 285.068 257.227687 
 L 278.372 257.227687 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 285.068 260.177462 
@@ -1294,7 +1294,7 @@ L 291.764 260.177462
 L 291.764 257.050445 
 L 285.068 257.050445 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 291.764 260.470074 
@@ -1302,7 +1302,7 @@ L 298.46 260.470074
 L 298.46 256.757833 
 L 291.764 256.757833 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 298.46 260.719375 
@@ -1310,7 +1310,7 @@ L 305.156 260.719375
 L 305.156 256.508532 
 L 298.46 256.508532 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 305.156 261.427442 
@@ -1318,7 +1318,7 @@ L 311.852 261.427442
 L 311.852 255.800465 
 L 305.156 255.800465 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 311.852 262.090943 
@@ -1326,7 +1326,7 @@ L 318.548 262.090943
 L 318.548 255.136964 
 L 311.852 255.136964 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 318.548 263.32182 
@@ -1334,7 +1334,7 @@ L 325.244 263.32182
 L 325.244 253.906087 
 L 318.548 253.906087 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 325.244 263.877508 
@@ -1342,7 +1342,7 @@ L 331.94 263.877508
 L 331.94 253.350399 
 L 325.244 253.350399 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 331.94 268.360163 
@@ -1350,7 +1350,7 @@ L 338.636 268.360163
 L 338.636 248.867744 
 L 331.94 248.867744 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 338.636 268.360163 
@@ -1358,7 +1358,7 @@ L 345.332 268.360163
 L 345.332 248.867744 
 L 338.636 248.867744 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 345.332 284.4 
@@ -1366,7 +1366,7 @@ L 352.028 284.4
 L 352.028 232.827907 
 L 345.332 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 352.028 276.847442 
@@ -1374,7 +1374,7 @@ L 358.724 276.847442
 L 358.724 240.380465 
 L 352.028 240.380465 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_56">
     <path d="M 358.724 284.4 
@@ -1382,7 +1382,7 @@ L 365.42 284.4
 L 365.42 232.827907 
 L 358.724 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_57">
     <path d="M 365.42 284.4 
@@ -1390,7 +1390,7 @@ L 372.116 284.4
 L 372.116 232.827907 
 L 365.42 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_58">
     <path d="M 372.116 284.4 
@@ -1398,7 +1398,7 @@ L 378.812 284.4
 L 378.812 232.827907 
 L 372.116 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_59">
     <path d="M 378.812 284.4 
@@ -1406,7 +1406,7 @@ L 385.508 284.4
 L 385.508 232.827907 
 L 378.812 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_60">
     <path d="M 385.508 284.4 
@@ -1414,7 +1414,7 @@ L 392.204 284.4
 L 392.204 232.827907 
 L 385.508 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_61">
     <path d="M 392.204 284.4 
@@ -1422,7 +1422,7 @@ L 398.9 284.4
 L 398.9 232.827907 
 L 392.204 232.827907 
 z
-" clip-path="url(#p31d6bd96fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p31d6bd96fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 67.448 284.4 
@@ -1973,15 +1973,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -2061,7 +2061,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/1d_elt1.svg
+++ b/docs/img/1d_elt1.svg
@@ -690,15 +690,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1048,12 +1048,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1089,7 +1089,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_10">
@@ -1105,7 +1105,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(369.3575 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_elt1_stacked.svg
+++ b/docs/img/1d_elt1_stacked.svg
@@ -888,15 +888,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1385,12 +1385,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1425,7 +1425,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_10">
@@ -1440,7 +1440,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(376.8575 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_elt2.svg
+++ b/docs/img/1d_elt2.svg
@@ -676,15 +676,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1034,12 +1034,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_fct.svg
+++ b/docs/img/1d_fct.svg
@@ -846,9 +846,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-66"/>
-      <use xlink:href="#LatinModernMath-Regular-28" x="30.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-78" x="69.499985"/>
-      <use xlink:href="#LatinModernMath-Regular-29" x="122.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-28" transform="translate(30.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-78" transform="translate(69.499985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-29" transform="translate(122.299973 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_fct_stacked.svg
+++ b/docs/img/1d_fct_stacked.svg
@@ -34,7 +34,7 @@ L 58.626875 7.2
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="PolyCollection_1">
+   <g id="FillBetweenPolyCollection_1">
     <path d="M 73.845057 228.685119 
 L 73.845057 228.721668 
 L 74.149725 228.716041 
@@ -2040,7 +2040,7 @@ L 73.845057 228.685119
 z
 " clip-path="url(#p4deaa227dd)" style="fill: #e24a33"/>
    </g>
-   <g id="PolyCollection_2">
+   <g id="FillBetweenPolyCollection_2">
     <path d="M 73.845057 228.721668 
 L 73.845057 228.96 
 L 74.149725 228.96 
@@ -4738,9 +4738,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-66"/>
-      <use xlink:href="#LatinModernMath-Regular-28" x="30.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-78" x="69.499985"/>
-      <use xlink:href="#LatinModernMath-Regular-29" x="122.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-28" transform="translate(30.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-78" transform="translate(69.499985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-29" transform="translate(122.299973 0)"/>
      </g>
     </g>
    </g>
@@ -4757,7 +4757,7 @@ z
      <!-- f2 -->
      <g style="fill: #1a1a1a" transform="translate(372.955625 26.4) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-66"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="30.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(30.599991 0)"/>
      </g>
     </g>
     <g id="patch_8">
@@ -4772,7 +4772,7 @@ z
      <!-- f1 -->
      <g style="fill: #1a1a1a" transform="translate(372.955625 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-66"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="30.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(30.599991 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_hist_simple.svg
+++ b/docs/img/1d_hist_simple.svg
@@ -907,15 +907,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1449,12 +1449,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_int_category.svg
+++ b/docs/img/1d_int_category.svg
@@ -141,8 +141,8 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#LatinModernMath-Regular-2d"/>
-       <use xlink:href="#LatinModernMath-Regular-31" x="33.299988"/>
-       <use xlink:href="#LatinModernMath-Regular-30" x="83.299973"/>
+       <use xlink:href="#LatinModernMath-Regular-31" transform="translate(33.299988 0)"/>
+       <use xlink:href="#LatinModernMath-Regular-30" transform="translate(83.299973 0)"/>
       </g>
      </g>
     </g>
@@ -244,7 +244,7 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#LatinModernMath-Regular-37"/>
-       <use xlink:href="#LatinModernMath-Regular-32" x="49.999985"/>
+       <use xlink:href="#LatinModernMath-Regular-32" transform="translate(49.999985 0)"/>
       </g>
      </g>
     </g>
@@ -502,21 +502,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-49"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="36.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="130.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="174.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="224.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="269.399948"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="308.599945"/>
-      <use xlink:href="#LatinModernMath-Regular-43" x="341.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="413.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="463.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="502.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="547.299896"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="597.299881"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="647.299866"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(36.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(130.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(174.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(224.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(269.399948 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(308.599945 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-43" transform="translate(341.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(413.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(463.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(502.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(547.299896 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(597.299881 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(647.299866 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(686.499863 0)"/>
      </g>
     </g>
    </g>
@@ -754,12 +754,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_profile.svg
+++ b/docs/img/1d_profile.svg
@@ -532,13 +532,13 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-56"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="74.999985"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="124.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="164.199966"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="191.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="241.999939"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="297.59993"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="325.399918"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(74.999985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(124.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(164.199966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(191.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(241.999939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(297.59993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(325.399918 0)"/>
      </g>
     </g>
    </g>
@@ -937,9 +937,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="136.099976"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="186.09996"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(136.099976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(186.09996 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_side_by_side.svg
+++ b/docs/img/1d_side_by_side.svg
@@ -443,13 +443,13 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-43"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="122.199966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="161.09996"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="205.499954"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="255.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="305.499924"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="344.699921"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(122.199966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(161.09996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(205.499954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(255.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(305.499924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(344.699921 0)"/>
      </g>
     </g>
    </g>
@@ -738,12 +738,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/1d_side_by_side_with_numbers.svg
+++ b/docs/img/1d_side_by_side_with_numbers.svg
@@ -238,9 +238,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#LatinModernMath-Regular-2d"/>
-       <use xlink:href="#LatinModernMath-Regular-31" x="33.299988"/>
-       <use xlink:href="#LatinModernMath-Regular-33" x="83.299973"/>
-       <use xlink:href="#LatinModernMath-Regular-37" x="133.299957"/>
+       <use xlink:href="#LatinModernMath-Regular-31" transform="translate(33.299988 0)"/>
+       <use xlink:href="#LatinModernMath-Regular-33" transform="translate(83.299973 0)"/>
+       <use xlink:href="#LatinModernMath-Regular-37" transform="translate(133.299957 0)"/>
       </g>
      </g>
     </g>
@@ -278,7 +278,7 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#LatinModernMath-Regular-31"/>
-       <use xlink:href="#LatinModernMath-Regular-32" x="49.999985"/>
+       <use xlink:href="#LatinModernMath-Regular-32" transform="translate(49.999985 0)"/>
       </g>
      </g>
     </g>
@@ -321,9 +321,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#LatinModernMath-Regular-31"/>
-       <use xlink:href="#LatinModernMath-Regular-32" x="49.999985"/>
-       <use xlink:href="#LatinModernMath-Regular-33" x="99.999969"/>
-       <use xlink:href="#LatinModernMath-Regular-34" x="149.999954"/>
+       <use xlink:href="#LatinModernMath-Regular-32" transform="translate(49.999985 0)"/>
+       <use xlink:href="#LatinModernMath-Regular-33" transform="translate(99.999969 0)"/>
+       <use xlink:href="#LatinModernMath-Regular-34" transform="translate(149.999954 0)"/>
       </g>
      </g>
     </g>
@@ -531,13 +531,13 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-43"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="72.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="122.199966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="161.09996"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="205.499954"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="255.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="305.499924"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="344.699921"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(72.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(122.199966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(161.09996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(205.499954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(255.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(305.499924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(344.699921 0)"/>
      </g>
     </g>
    </g>
@@ -811,12 +811,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -853,21 +853,21 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_14">
     <!-- 12 -->
     <g transform="translate(175.60625 142.550531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-32" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_15">
     <!-- 20 -->
     <g transform="translate(287.20625 83.414531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-32"/>
-     <use xlink:href="#LatinModernMath-Regular-30" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_16">
@@ -900,7 +900,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-36" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-36" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_17">
@@ -919,21 +919,21 @@ z
     <!-- 10 -->
     <g transform="translate(108.64625 157.334531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-30" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-30" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 13 -->
     <g transform="translate(220.24625 135.158531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-33" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- 12 -->
     <g transform="translate(331.84625 142.550531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-32" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -979,7 +979,7 @@ z
     <!-- 15 -->
     <g transform="translate(354.16625 120.374531) scale(0.15 -0.15)">
      <use xlink:href="#LatinModernMath-Regular-31"/>
-     <use xlink:href="#LatinModernMath-Regular-35" x="49.999985"/>
+     <use xlink:href="#LatinModernMath-Regular-35" transform="translate(49.999985 0)"/>
     </g>
    </g>
    <g id="legend_1">

--- a/docs/img/1d_str_category.svg
+++ b/docs/img/1d_str_category.svg
@@ -454,20 +454,20 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="94.499985"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="133.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="161.499969"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="217.09996"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="267.099945"/>
-      <use xlink:href="#LatinModernMath-Regular-43" x="300.299942"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="372.499924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="422.499908"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="461.399902"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="505.799896"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="555.799881"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="605.799866"/>
-      <use xlink:href="#LatinModernMath-Regular-79" x="644.999863"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(94.499985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(133.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(161.499969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(217.09996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(267.099945 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-43" transform="translate(300.299942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(372.499924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(422.499908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(461.399902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(505.799896 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(555.799881 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(605.799866 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-79" transform="translate(644.999863 0)"/>
      </g>
     </g>
    </g>
@@ -780,12 +780,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_correlations_0.svg
+++ b/docs/img/2d_hist_correlations_0.svg
@@ -15495,15 +15495,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -15916,15 +15916,15 @@ L 3 0
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(19.693125 171.852727) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -16320,12 +16320,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_correlations_1.svg
+++ b/docs/img/2d_hist_correlations_1.svg
@@ -15495,15 +15495,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -15833,15 +15833,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -16301,12 +16301,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_correlations_2.svg
+++ b/docs/img/2d_hist_correlations_2.svg
@@ -15482,15 +15482,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -15820,15 +15820,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -16224,12 +16224,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_simple.svg
+++ b/docs/img/2d_hist_simple.svg
@@ -1049,15 +1049,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1466,15 +1466,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1873,12 +1873,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_simple_discrete_colormap.svg
+++ b/docs/img/2d_hist_simple_discrete_colormap.svg
@@ -15484,15 +15484,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -15695,15 +15695,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -16273,12 +16273,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/2d_hist_uneven.svg
+++ b/docs/img/2d_hist_uneven.svg
@@ -543,15 +543,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -990,15 +990,15 @@ L 3 0
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(19.693125 184.131094) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -1438,12 +1438,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
     <g id="text_24">

--- a/docs/img/2d_hist_with_projections.svg
+++ b/docs/img/2d_hist_with_projections.svg
@@ -15381,15 +15381,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -15605,15 +15605,15 @@ L 3 0
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(19.693125 277.428545) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -16191,12 +16191,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -16496,12 +16496,12 @@ L 398.98625 134.968388
      <!-- Entries -->
      <g style="fill: #1a1a1a" transform="translate(319.690077 382.143388) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -16801,12 +16801,12 @@ L -3 0
      <!-- Entries -->
      <g style="fill: #1a1a1a" transform="translate(368.888466 88.654951) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/asymmetry_comparison_advanced.svg
+++ b/docs/img/asymmetry_comparison_advanced.svg
@@ -1305,12 +1305,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2750,15 +2750,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -3057,38 +3057,38 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-44"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="215.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="248.499954"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="298.499939"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="354.09993"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="409.699921"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="442.899918"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="473.499908"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="501.299896"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="540.19989"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="573.399887"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="623.399872"/>
-     <use xlink:href="#LatinModernMath-Regular-79" x="662.799866"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="715.599854"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="798.899841"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="882.199829"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="926.599823"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="965.499817"/>
-     <use xlink:href="#LatinModernMath-Regular-79" x="1004.699814"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="1057.499802"/>
-     <use xlink:href="#LatinModernMath-Regular-63" x="1090.699799"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="1135.099792"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="1185.099777"/>
-     <use xlink:href="#LatinModernMath-Regular-70" x="1268.399765"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="1323.999756"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="1373.999741"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="1413.199738"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="1440.999725"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="1480.399719"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="1530.399704"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(215.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(248.499954 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(298.499939 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(354.09993 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(409.699921 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(442.899918 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(473.499908 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(501.299896 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(540.19989 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(573.399887 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(623.399872 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-79" transform="translate(662.799866 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(715.599854 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(798.899841 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(882.199829 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(926.599823 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(965.499817 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-79" transform="translate(1004.699814 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(1057.499802 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-63" transform="translate(1090.699799 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(1135.099792 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(1185.099777 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-70" transform="translate(1268.399765 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(1323.999756 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(1373.999741 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(1413.199738 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(1440.999725 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(1480.399719 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(1530.399704 0)"/>
     </g>
    </g>
   </g>

--- a/docs/img/matplotlib_example.svg
+++ b/docs/img/matplotlib_example.svg
@@ -182,9 +182,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
       </g>
      </g>
     </g>
@@ -219,9 +219,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-34"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
       </g>
      </g>
     </g>
@@ -267,9 +267,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-36"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
       </g>
      </g>
     </g>
@@ -324,9 +324,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-38"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
       </g>
      </g>
     </g>
@@ -356,10 +356,10 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
-       <use xlink:href="#DejaVuSans-30" x="254.492188"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
       </g>
      </g>
     </g>
@@ -373,10 +373,10 @@ z
       <!-- 12000 -->
       <g transform="translate(20.878125 71.582092) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
-       <use xlink:href="#DejaVuSans-30" x="254.492188"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
       </g>
      </g>
     </g>
@@ -390,10 +390,10 @@ z
       <!-- 14000 -->
       <g transform="translate(20.878125 44.54733) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
-       <use xlink:href="#DejaVuSans-30" x="254.492188"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
       </g>
      </g>
     </g>
@@ -407,10 +407,10 @@ z
       <!-- 16000 -->
       <g transform="translate(20.878125 17.512569) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
-       <use xlink:href="#DejaVuSans-30" x="254.492188"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
       </g>
      </g>
     </g>
@@ -561,12 +561,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-6e" x="63.183594"/>
-      <use xlink:href="#DejaVuSans-74" x="126.5625"/>
-      <use xlink:href="#DejaVuSans-72" x="165.771484"/>
-      <use xlink:href="#DejaVuSans-69" x="206.884766"/>
-      <use xlink:href="#DejaVuSans-65" x="234.667969"/>
-      <use xlink:href="#DejaVuSans-73" x="296.191406"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(63.183594 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(126.5625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(165.771484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(206.884766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(234.667969 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(296.191406 0)"/>
      </g>
     </g>
    </g>
@@ -728,7 +728,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-68"/>
-      <use xlink:href="#DejaVuSans-31" x="63.378906"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(63.378906 0)"/>
      </g>
     </g>
     <g id="patch_11">
@@ -744,7 +744,7 @@ z
      <!-- h2 -->
      <g transform="translate(372.790625 38.476562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-68"/>
-      <use xlink:href="#DejaVuSans-32" x="63.378906"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(63.378906 0)"/>
      </g>
     </g>
    </g>
@@ -785,10 +785,10 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-31" x="83.789062"/>
-       <use xlink:href="#DejaVuSans-30" x="147.412109"/>
-       <use xlink:href="#DejaVuSans-2e" x="211.035156"/>
-       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(211.035156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
       </g>
      </g>
     </g>
@@ -839,9 +839,9 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-37" x="83.789062"/>
-       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
-       <use xlink:href="#DejaVuSans-35" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
       </g>
      </g>
     </g>
@@ -855,9 +855,9 @@ z
       <!-- −5.0 -->
       <g transform="translate(131.249219 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-35" x="83.789062"/>
-       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
-       <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
       </g>
      </g>
     </g>
@@ -871,9 +871,9 @@ z
       <!-- −2.5 -->
       <g transform="translate(173.099219 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-32" x="83.789062"/>
-       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
-       <use xlink:href="#DejaVuSans-35" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
       </g>
      </g>
     </g>
@@ -887,8 +887,8 @@ z
       <!-- 0.0 -->
       <g transform="translate(219.139063 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
@@ -902,8 +902,8 @@ z
       <!-- 2.5 -->
       <g transform="translate(260.989062 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
@@ -917,8 +917,8 @@ z
       <!-- 5.0 -->
       <g transform="translate(302.839063 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
@@ -932,8 +932,8 @@ z
       <!-- 7.5 -->
       <g transform="translate(344.689062 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-37"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
@@ -947,9 +947,9 @@ z
       <!-- 10.0 -->
       <g transform="translate(383.357813 321.174438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
       </g>
      </g>
     </g>
@@ -1035,13 +1035,13 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-56"/>
-      <use xlink:href="#DejaVuSans-61" x="60.658203"/>
-      <use xlink:href="#DejaVuSans-72" x="121.9375"/>
-      <use xlink:href="#DejaVuSans-69" x="163.050781"/>
-      <use xlink:href="#DejaVuSans-61" x="190.833984"/>
-      <use xlink:href="#DejaVuSans-62" x="252.113281"/>
-      <use xlink:href="#DejaVuSans-6c" x="315.589844"/>
-      <use xlink:href="#DejaVuSans-65" x="343.373047"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(60.658203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(121.9375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(163.050781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(190.833984 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(252.113281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(315.589844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(343.373047 0)"/>
      </g>
     </g>
    </g>
@@ -1140,10 +1140,10 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-52"/>
-      <use xlink:href="#DejaVuSans-61" x="67.232422"/>
-      <use xlink:href="#DejaVuSans-74" x="128.511719"/>
-      <use xlink:href="#DejaVuSans-69" x="167.720703"/>
-      <use xlink:href="#DejaVuSans-6f" x="195.503906"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(67.232422 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(128.511719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(167.720703 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(195.503906 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/model_all_comparisons.svg
+++ b/docs/img/model_all_comparisons.svg
@@ -652,7 +652,7 @@ L 86.546 236.49816
 L 86.546 236.348243 
 L 79.85 236.348243 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 86.546 236.403116 
@@ -660,7 +660,7 @@ L 93.242 236.403116
 L 93.242 236.143452 
 L 86.546 236.143452 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 93.242 236.110506 
@@ -668,7 +668,7 @@ L 99.938 236.110506
 L 99.938 235.686476 
 L 93.242 235.686476 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 99.938 235.793965 
@@ -676,7 +676,7 @@ L 106.634 235.793965
 L 106.634 235.253431 
 L 99.938 235.253431 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 106.634 234.863773 
@@ -684,7 +684,7 @@ L 113.33 234.863773
 L 113.33 234.08478 
 L 106.634 234.08478 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 113.33 233.558457 
@@ -692,7 +692,7 @@ L 120.026 233.558457
 L 120.026 232.541669 
 L 113.33 232.541669 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 120.026 231.313403 
@@ -700,7 +700,7 @@ L 126.722 231.313403
 L 126.722 229.98937 
 L 120.026 229.98937 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 126.722 225.740846 
@@ -708,7 +708,7 @@ L 133.418 225.740846
 L 133.418 223.86838 
 L 126.722 223.86838 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 133.418 217.85436 
@@ -716,7 +716,7 @@ L 140.114 217.85436
 L 140.114 215.413884 
 L 133.418 215.413884 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 140.114 211.664986 
@@ -724,7 +724,7 @@ L 146.81 211.664986
 L 146.81 208.860291 
 L 140.114 208.860291 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 146.81 190.347477 
@@ -732,7 +732,7 @@ L 153.506 190.347477
 L 153.506 186.551875 
 L 146.81 186.551875 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 153.506 175.263409 
@@ -740,7 +740,7 @@ L 160.202 175.263409
 L 160.202 170.902903 
 L 153.506 170.902903 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 160.202 151.951427 
@@ -748,7 +748,7 @@ L 166.898 151.951427
 L 166.898 146.841029 
 L 160.202 146.841029 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 166.898 128.886999 
@@ -756,7 +756,7 @@ L 173.594 128.886999
 L 173.594 123.131269 
 L 166.898 123.131269 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 173.594 106.16023 
@@ -764,7 +764,7 @@ L 180.29 106.16023
 L 180.29 99.833437 
 L 173.594 99.833437 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 180.29 91.044929 
@@ -772,7 +772,7 @@ L 186.986 91.044929
 L 186.986 84.365615 
 L 180.29 84.365615 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 186.986 82.668346 
@@ -780,7 +780,7 @@ L 193.682 82.668346
 L 193.682 75.801546 
 L 186.986 75.801546 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 193.682 82.075217 
@@ -788,7 +788,7 @@ L 200.378 82.075217
 L 200.378 75.195338 
 L 193.682 75.195338 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 200.378 91.48963 
@@ -796,7 +796,7 @@ L 207.074 91.48963
 L 207.074 84.820418 
 L 200.378 84.820418 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 207.074 98.603774 
@@ -804,7 +804,7 @@ L 213.77 98.603774
 L 213.77 92.098332 
 L 207.074 92.098332 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 213.77 108.456296 
@@ -812,7 +812,7 @@ L 220.466 108.456296
 L 220.466 102.184806 
 L 213.77 102.184806 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 220.466 115.34299 
@@ -820,7 +820,7 @@ L 227.162 115.34299
 L 227.162 109.240418 
 L 220.466 109.240418 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 227.162 130.070675 
@@ -828,7 +828,7 @@ L 233.858 130.070675
 L 233.858 124.346269 
 L 227.162 124.346269 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 233.858 125.039473 
@@ -836,7 +836,7 @@ L 240.554 125.039473
 L 240.554 119.183097 
 L 233.858 119.183097 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 240.554 127.999186 
@@ -844,7 +844,7 @@ L 247.25 127.999186
 L 247.25 122.220075 
 L 240.554 122.220075 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 247.25 126.149425 
@@ -852,7 +852,7 @@ L 253.946 126.149425
 L 253.946 120.321904 
 L 247.25 120.321904 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 253.946 135.026366 
@@ -860,7 +860,7 @@ L 260.642 135.026366
 L 260.642 129.435035 
 L 253.946 129.435035 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 260.642 146.558486 
@@ -868,7 +868,7 @@ L 267.338 146.558486
 L 267.338 141.290009 
 L 260.642 141.290009 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 267.338 156.82507 
@@ -876,7 +876,7 @@ L 274.034 156.82507
 L 274.034 151.861925 
 L 267.338 151.861925 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 274.034 168.777638 
@@ -884,7 +884,7 @@ L 280.73 168.777638
 L 280.73 164.195954 
 L 274.034 164.195954 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 280.73 179.240445 
@@ -892,7 +892,7 @@ L 287.426 179.240445
 L 287.426 175.021399 
 L 280.73 175.021399 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 287.426 197.689032 
@@ -900,7 +900,7 @@ L 294.122 197.689032
 L 294.122 194.202046 
 L 287.426 194.202046 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 294.122 209.109881 
@@ -908,7 +908,7 @@ L 300.818 209.109881
 L 300.818 206.168291 
 L 294.122 206.168291 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 300.818 218.435469 
@@ -916,7 +916,7 @@ L 307.514 218.435469
 L 307.514 216.032113 
 L 300.818 216.032113 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 307.514 224.588348 
@@ -924,7 +924,7 @@ L 314.21 224.588348
 L 314.21 222.622202 
 L 307.514 222.622202 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 314.21 229.609424 
@@ -932,7 +932,7 @@ L 320.906 229.609424
 L 320.906 228.095334 
 L 314.21 228.095334 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 320.906 232.651369 
@@ -940,7 +940,7 @@ L 327.602 232.651369
 L 327.602 231.499832 
 L 320.906 231.499832 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 327.602 234.591794 
@@ -948,7 +948,7 @@ L 334.298 234.591794
 L 334.298 233.75709 
 L 327.602 233.75709 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 334.298 235.200657 
@@ -956,7 +956,7 @@ L 340.994 235.200657
 L 340.994 234.497483 
 L 334.298 234.497483 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 340.994 236.171771 
@@ -964,7 +964,7 @@ L 347.69 236.171771
 L 347.69 235.775128 
 L 340.994 235.775128 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 347.69 236.232019 
@@ -972,7 +972,7 @@ L 354.386 236.232019
 L 354.386 235.864798 
 L 347.69 235.864798 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 354.386 236.45425 
@@ -980,7 +980,7 @@ L 361.082 236.45425
 L 361.082 236.242235 
 L 354.386 236.242235 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 361.082 236.49816 
@@ -988,7 +988,7 @@ L 367.778 236.49816
 L 367.778 236.348243 
 L 361.082 236.348243 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 367.778 236.49816 
@@ -996,7 +996,7 @@ L 374.474 236.49816
 L 374.474 236.348243 
 L 367.778 236.348243 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 374.474 236.49816 
@@ -1004,7 +1004,7 @@ L 381.17 236.49816
 L 381.17 236.49816 
 L 374.474 236.49816 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 381.17 236.49816 
@@ -1012,7 +1012,7 @@ L 387.866 236.49816
 L 387.866 236.348243 
 L 381.17 236.348243 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 387.866 236.49816 
@@ -1020,7 +1020,7 @@ L 394.562 236.49816
 L 394.562 236.348243 
 L 387.866 236.348243 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 394.562 236.49816 
@@ -1028,7 +1028,7 @@ L 401.258 236.49816
 L 401.258 236.49816 
 L 394.562 236.49816 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 401.258 236.49816 
@@ -1036,7 +1036,7 @@ L 407.954 236.49816
 L 407.954 236.49816 
 L 401.258 236.49816 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 407.954 236.49816 
@@ -1044,7 +1044,7 @@ L 414.65 236.49816
 L 414.65 236.49816 
 L 407.954 236.49816 
 z
-" clip-path="url(#p57821d3ea5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p57821d3ea5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 83.198 236.459271 
@@ -1938,12 +1938,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2422,7 +2422,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(318.1325 39.48216) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_61">
@@ -2456,7 +2456,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_62">
@@ -2471,7 +2471,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(318.1325 72.93966) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -2480,7 +2480,7 @@ L 308.5325 89.66841
 L 308.5325 81.26841 
 L 284.5325 81.26841 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_11">
      <!-- Model stat. unc. -->
@@ -2495,21 +2495,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2554,9 +2554,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -3187,7 +3187,7 @@ L 86.546 438.29976
 L 86.546 366.22776 
 L 79.85 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_71">
     <path d="M 86.546 423.069154 
@@ -3195,7 +3195,7 @@ L 93.242 423.069154
 L 93.242 381.458366 
 L 86.546 381.458366 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_72">
     <path d="M 93.242 415.00441 
@@ -3203,7 +3203,7 @@ L 99.938 415.00441
 L 99.938 389.52311 
 L 93.242 389.52311 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_73">
     <path d="M 99.938 412.258348 
@@ -3211,7 +3211,7 @@ L 106.634 412.258348
 L 106.634 392.269172 
 L 99.938 392.269172 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_74">
     <path d="M 106.634 409.198891 
@@ -3219,7 +3219,7 @@ L 113.33 409.198891
 L 113.33 395.328629 
 L 106.634 395.328629 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_75">
     <path d="M 113.33 407.576978 
@@ -3227,7 +3227,7 @@ L 120.026 407.576978
 L 120.026 396.950542 
 L 113.33 396.950542 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_76">
     <path d="M 120.026 406.344034 
@@ -3235,7 +3235,7 @@ L 126.722 406.344034
 L 126.722 398.183486 
 L 120.026 398.183486 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_77">
     <path d="M 126.722 405.148949 
@@ -3243,7 +3243,7 @@ L 133.418 405.148949
 L 133.418 399.378571 
 L 126.722 399.378571 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_78">
     <path d="M 133.418 404.477434 
@@ -3251,7 +3251,7 @@ L 140.114 404.477434
 L 140.114 400.050086 
 L 133.418 400.050086 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_79">
     <path d="M 140.114 404.189965 
@@ -3259,7 +3259,7 @@ L 146.81 404.189965
 L 146.81 400.337555 
 L 140.114 400.337555 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_80">
     <path d="M 146.81 403.687096 
@@ -3267,7 +3267,7 @@ L 153.506 403.687096
 L 153.506 400.840424 
 L 146.81 400.840424 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_81">
     <path d="M 153.506 403.502703 
@@ -3275,7 +3275,7 @@ L 160.202 403.502703
 L 160.202 401.024817 
 L 153.506 401.024817 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_82">
     <path d="M 160.202 403.320902 
@@ -3283,7 +3283,7 @@ L 166.898 403.320902
 L 166.898 401.206618 
 L 160.202 401.206618 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_83">
     <path d="M 166.898 403.202376 
@@ -3291,7 +3291,7 @@ L 173.594 403.202376
 L 173.594 401.325144 
 L 166.898 401.325144 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_84">
     <path d="M 173.594 403.117655 
@@ -3299,7 +3299,7 @@ L 180.29 403.117655
 L 180.29 401.409865 
 L 173.594 401.409865 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_85">
     <path d="M 180.29 403.072588 
@@ -3307,7 +3307,7 @@ L 186.986 403.072588
 L 186.986 401.454932 
 L 180.29 401.454932 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_86">
     <path d="M 186.986 403.050505 
@@ -3315,7 +3315,7 @@ L 193.682 403.050505
 L 193.682 401.477015 
 L 186.986 401.477015 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_87">
     <path d="M 193.682 403.049009 
@@ -3323,7 +3323,7 @@ L 200.378 403.049009
 L 200.378 401.478511 
 L 193.682 401.478511 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_88">
     <path d="M 200.378 403.073813 
@@ -3331,7 +3331,7 @@ L 207.074 403.073813
 L 207.074 401.453707 
 L 200.378 401.453707 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_89">
     <path d="M 207.074 403.094206 
@@ -3339,7 +3339,7 @@ L 213.77 403.094206
 L 213.77 401.433314 
 L 207.074 401.433314 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_90">
     <path d="M 213.77 403.125185 
@@ -3347,7 +3347,7 @@ L 220.466 403.125185
 L 220.466 401.402335 
 L 213.77 401.402335 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_91">
     <path d="M 220.466 403.149029 
@@ -3355,7 +3355,7 @@ L 227.162 403.149029
 L 227.162 401.378491 
 L 220.466 401.378491 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_92">
     <path d="M 227.162 403.207512 
@@ -3363,7 +3363,7 @@ L 233.858 403.207512
 L 233.858 401.320008 
 L 227.162 401.320008 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_93">
     <path d="M 233.858 403.186245 
@@ -3371,7 +3371,7 @@ L 240.554 403.186245
 L 240.554 401.341275 
 L 233.858 401.341275 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_94">
     <path d="M 240.554 403.198578 
@@ -3379,7 +3379,7 @@ L 247.25 403.198578
 L 247.25 401.328942 
 L 240.554 401.328942 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_95">
     <path d="M 247.25 403.190813 
@@ -3387,7 +3387,7 @@ L 253.946 403.190813
 L 253.946 401.336707 
 L 247.25 401.336707 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_96">
     <path d="M 253.946 403.229973 
@@ -3395,7 +3395,7 @@ L 260.642 403.229973
 L 260.642 401.297547 
 L 253.946 401.297547 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_97">
     <path d="M 260.642 403.289183 
@@ -3403,7 +3403,7 @@ L 267.338 403.289183
 L 267.338 401.238337 
 L 260.642 401.238337 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_98">
     <path d="M 267.338 403.352267 
@@ -3411,7 +3411,7 @@ L 274.034 403.352267
 L 274.034 401.175253 
 L 267.338 401.175253 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_99">
     <path d="M 274.034 403.442894 
@@ -3419,7 +3419,7 @@ L 280.73 403.442894
 L 280.73 401.084626 
 L 274.034 401.084626 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_100">
     <path d="M 280.73 403.544244 
@@ -3427,7 +3427,7 @@ L 287.426 403.544244
 L 287.426 400.983276 
 L 280.73 400.983276 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_101">
     <path d="M 287.426 403.813069 
@@ -3435,7 +3435,7 @@ L 294.122 403.813069
 L 294.122 400.714451 
 L 287.426 400.714451 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_102">
     <path d="M 294.122 404.100325 
@@ -3443,7 +3443,7 @@ L 300.818 404.100325
 L 300.818 400.427195 
 L 294.122 400.427195 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_103">
     <path d="M 300.818 404.511624 
@@ -3451,7 +3451,7 @@ L 307.514 404.511624
 L 307.514 400.015896 
 L 300.818 400.015896 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_104">
     <path d="M 307.514 405.011479 
@@ -3459,7 +3459,7 @@ L 314.21 405.011479
 L 314.21 399.516041 
 L 307.514 399.516041 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_105">
     <path d="M 314.21 405.831856 
@@ -3467,7 +3467,7 @@ L 320.906 405.831856
 L 320.906 398.695664 
 L 314.21 398.695664 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_106">
     <path d="M 320.906 406.955248 
@@ -3475,7 +3475,7 @@ L 327.602 406.955248
 L 327.602 397.572272 
 L 320.906 397.572272 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_107">
     <path d="M 327.602 408.736017 
@@ -3483,7 +3483,7 @@ L 334.298 408.736017
 L 334.298 395.791503 
 L 327.602 395.791503 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_108">
     <path d="M 334.298 409.946661 
@@ -3491,7 +3491,7 @@ L 340.994 409.946661
 L 340.994 394.580859 
 L 334.298 394.580859 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_109">
     <path d="M 340.994 415.884088 
@@ -3499,7 +3499,7 @@ L 347.69 415.884088
 L 347.69 388.643432 
 L 340.994 388.643432 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_110">
     <path d="M 347.69 416.975395 
@@ -3507,7 +3507,7 @@ L 354.386 416.975395
 L 354.386 387.552125 
 L 347.69 387.552125 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_111">
     <path d="M 354.386 427.74506 
@@ -3515,7 +3515,7 @@ L 361.082 427.74506
 L 361.082 376.78246 
 L 354.386 376.78246 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_112">
     <path d="M 361.082 438.29976 
@@ -3523,7 +3523,7 @@ L 367.778 438.29976
 L 367.778 366.22776 
 L 361.082 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_113">
     <path d="M 367.778 438.29976 
@@ -3531,7 +3531,7 @@ L 374.474 438.29976
 L 374.474 366.22776 
 L 367.778 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_114">
     <path d="M 374.474 438.29976 
@@ -3539,7 +3539,7 @@ L 381.17 438.29976
 L 381.17 366.22776 
 L 374.474 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_115">
     <path d="M 381.17 438.29976 
@@ -3547,7 +3547,7 @@ L 387.866 438.29976
 L 387.866 366.22776 
 L 381.17 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_116">
     <path d="M 387.866 438.29976 
@@ -3555,7 +3555,7 @@ L 394.562 438.29976
 L 394.562 366.22776 
 L 387.866 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_117">
     <path d="M 394.562 438.29976 
@@ -3563,7 +3563,7 @@ L 401.258 438.29976
 L 401.258 366.22776 
 L 394.562 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_118">
     <path d="M 401.258 438.29976 
@@ -3571,7 +3571,7 @@ L 407.954 438.29976
 L 407.954 366.22776 
 L 401.258 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_119">
     <path d="M 407.954 438.29976 
@@ -3579,7 +3579,7 @@ L 414.65 438.29976
 L 414.65 366.22776 
 L 407.954 366.22776 
 z
-" clip-path="url(#pf1155c465b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf1155c465b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 83.198 419.60406 
@@ -5818,15 +5818,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -5989,7 +5989,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_all_comparisons_no_model_unc.svg
+++ b/docs/img/model_all_comparisons_no_model_unc.svg
@@ -1538,12 +1538,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2085,7 +2085,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(374.1425 39.48216) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_11">
@@ -2119,7 +2119,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_12">
@@ -2134,7 +2134,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(374.1425 72.93966) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2179,9 +2179,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -2819,7 +2819,7 @@ L 82.676 402.26376
 L 82.676 402.26376 
 L 75.98 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 82.676 402.26376 
@@ -2827,7 +2827,7 @@ L 89.372 402.26376
 L 89.372 402.26376 
 L 82.676 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 89.372 402.26376 
@@ -2835,7 +2835,7 @@ L 96.068 402.26376
 L 96.068 402.26376 
 L 89.372 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 96.068 402.26376 
@@ -2843,7 +2843,7 @@ L 102.764 402.26376
 L 102.764 402.26376 
 L 96.068 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 102.764 402.26376 
@@ -2851,7 +2851,7 @@ L 109.46 402.26376
 L 109.46 402.26376 
 L 102.764 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 109.46 402.26376 
@@ -2859,7 +2859,7 @@ L 116.156 402.26376
 L 116.156 402.26376 
 L 109.46 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 116.156 402.26376 
@@ -2867,7 +2867,7 @@ L 122.852 402.26376
 L 122.852 402.26376 
 L 116.156 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 122.852 402.26376 
@@ -2875,7 +2875,7 @@ L 129.548 402.26376
 L 129.548 402.26376 
 L 122.852 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 129.548 402.26376 
@@ -2883,7 +2883,7 @@ L 136.244 402.26376
 L 136.244 402.26376 
 L 129.548 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 136.244 402.26376 
@@ -2891,7 +2891,7 @@ L 142.94 402.26376
 L 142.94 402.26376 
 L 136.244 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 142.94 402.26376 
@@ -2899,7 +2899,7 @@ L 149.636 402.26376
 L 149.636 402.26376 
 L 142.94 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 149.636 402.26376 
@@ -2907,7 +2907,7 @@ L 156.332 402.26376
 L 156.332 402.26376 
 L 149.636 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 156.332 402.26376 
@@ -2915,7 +2915,7 @@ L 163.028 402.26376
 L 163.028 402.26376 
 L 156.332 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 163.028 402.26376 
@@ -2923,7 +2923,7 @@ L 169.724 402.26376
 L 169.724 402.26376 
 L 163.028 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 169.724 402.26376 
@@ -2931,7 +2931,7 @@ L 176.42 402.26376
 L 176.42 402.26376 
 L 169.724 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 176.42 402.26376 
@@ -2939,7 +2939,7 @@ L 183.116 402.26376
 L 183.116 402.26376 
 L 176.42 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 183.116 402.26376 
@@ -2947,7 +2947,7 @@ L 189.812 402.26376
 L 189.812 402.26376 
 L 183.116 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 189.812 402.26376 
@@ -2955,7 +2955,7 @@ L 196.508 402.26376
 L 196.508 402.26376 
 L 189.812 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 196.508 402.26376 
@@ -2963,7 +2963,7 @@ L 203.204 402.26376
 L 203.204 402.26376 
 L 196.508 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 203.204 402.26376 
@@ -2971,7 +2971,7 @@ L 209.9 402.26376
 L 209.9 402.26376 
 L 203.204 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 209.9 402.26376 
@@ -2979,7 +2979,7 @@ L 216.596 402.26376
 L 216.596 402.26376 
 L 209.9 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 216.596 402.26376 
@@ -2987,7 +2987,7 @@ L 223.292 402.26376
 L 223.292 402.26376 
 L 216.596 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 223.292 402.26376 
@@ -2995,7 +2995,7 @@ L 229.988 402.26376
 L 229.988 402.26376 
 L 223.292 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 229.988 402.26376 
@@ -3003,7 +3003,7 @@ L 236.684 402.26376
 L 236.684 402.26376 
 L 229.988 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 236.684 402.26376 
@@ -3011,7 +3011,7 @@ L 243.38 402.26376
 L 243.38 402.26376 
 L 236.684 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 243.38 402.26376 
@@ -3019,7 +3019,7 @@ L 250.076 402.26376
 L 250.076 402.26376 
 L 243.38 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 250.076 402.26376 
@@ -3027,7 +3027,7 @@ L 256.772 402.26376
 L 256.772 402.26376 
 L 250.076 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 256.772 402.26376 
@@ -3035,7 +3035,7 @@ L 263.468 402.26376
 L 263.468 402.26376 
 L 256.772 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 263.468 402.26376 
@@ -3043,7 +3043,7 @@ L 270.164 402.26376
 L 270.164 402.26376 
 L 263.468 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 270.164 402.26376 
@@ -3051,7 +3051,7 @@ L 276.86 402.26376
 L 276.86 402.26376 
 L 270.164 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 276.86 402.26376 
@@ -3059,7 +3059,7 @@ L 283.556 402.26376
 L 283.556 402.26376 
 L 276.86 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 283.556 402.26376 
@@ -3067,7 +3067,7 @@ L 290.252 402.26376
 L 290.252 402.26376 
 L 283.556 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 290.252 402.26376 
@@ -3075,7 +3075,7 @@ L 296.948 402.26376
 L 296.948 402.26376 
 L 290.252 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 296.948 402.26376 
@@ -3083,7 +3083,7 @@ L 303.644 402.26376
 L 303.644 402.26376 
 L 296.948 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 303.644 402.26376 
@@ -3091,7 +3091,7 @@ L 310.34 402.26376
 L 310.34 402.26376 
 L 303.644 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 310.34 402.26376 
@@ -3099,7 +3099,7 @@ L 317.036 402.26376
 L 317.036 402.26376 
 L 310.34 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 317.036 402.26376 
@@ -3107,7 +3107,7 @@ L 323.732 402.26376
 L 323.732 402.26376 
 L 317.036 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_56">
     <path d="M 323.732 402.26376 
@@ -3115,7 +3115,7 @@ L 330.428 402.26376
 L 330.428 402.26376 
 L 323.732 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_57">
     <path d="M 330.428 402.26376 
@@ -3123,7 +3123,7 @@ L 337.124 402.26376
 L 337.124 402.26376 
 L 330.428 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_58">
     <path d="M 337.124 402.26376 
@@ -3131,7 +3131,7 @@ L 343.82 402.26376
 L 343.82 402.26376 
 L 337.124 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_59">
     <path d="M 343.82 402.26376 
@@ -3139,7 +3139,7 @@ L 350.516 402.26376
 L 350.516 402.26376 
 L 343.82 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_60">
     <path d="M 350.516 402.26376 
@@ -3147,7 +3147,7 @@ L 357.212 402.26376
 L 357.212 402.26376 
 L 350.516 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_61">
     <path d="M 357.212 402.26376 
@@ -3155,7 +3155,7 @@ L 363.908 402.26376
 L 363.908 402.26376 
 L 357.212 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_62">
     <path d="M 363.908 402.26376 
@@ -3163,7 +3163,7 @@ L 370.604 402.26376
 L 370.604 402.26376 
 L 363.908 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_63">
     <path d="M 370.604 438.29976 
@@ -3171,7 +3171,7 @@ L 377.3 438.29976
 L 377.3 366.22776 
 L 370.604 366.22776 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_64">
     <path d="M 377.3 402.26376 
@@ -3179,7 +3179,7 @@ L 383.996 402.26376
 L 383.996 402.26376 
 L 377.3 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_65">
     <path d="M 383.996 402.26376 
@@ -3187,7 +3187,7 @@ L 390.692 402.26376
 L 390.692 402.26376 
 L 383.996 402.26376 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_66">
     <path d="M 390.692 438.29976 
@@ -3195,7 +3195,7 @@ L 397.388 438.29976
 L 397.388 366.22776 
 L 390.692 366.22776 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_67">
     <path d="M 397.388 438.29976 
@@ -3203,7 +3203,7 @@ L 404.084 438.29976
 L 404.084 366.22776 
 L 397.388 366.22776 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_68">
     <path d="M 404.084 438.29976 
@@ -3211,7 +3211,7 @@ L 410.78 438.29976
 L 410.78 366.22776 
 L 404.084 366.22776 
 z
-" clip-path="url(#pf12654647c)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf12654647c)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 79.328 419.60406 
@@ -5398,15 +5398,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -5569,7 +5569,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_examples_flatten2D.svg
+++ b/docs/img/model_examples_flatten2D.svg
@@ -292,7 +292,7 @@ L 102.83 174.413954
 L 102.83 172.989904 
 L 60.98 172.989904 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 102.83 100.801211 
@@ -300,7 +300,7 @@ L 144.68 100.801211
 L 144.68 98.599186 
 L 102.83 98.599186 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 144.68 99.719464 
@@ -308,7 +308,7 @@ L 186.53 99.719464
 L 186.53 97.508055 
 L 144.68 97.508055 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 186.53 208.62326 
@@ -316,7 +316,7 @@ L 228.38 208.62326
 L 228.38 207.778992 
 L 186.53 207.778992 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 228.38 202.352028 
@@ -324,7 +324,7 @@ L 270.23 202.352028
 L 270.23 201.375105 
 L 228.38 201.375105 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 270.23 108.192596 
@@ -332,7 +332,7 @@ L 312.08 108.192596
 L 312.08 106.055798 
 L 270.23 106.055798 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 312.08 33.161353 
@@ -340,7 +340,7 @@ L 353.93 33.161353
 L 353.93 30.434193 
 L 312.08 30.434193 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 353.93 164.253516 
@@ -348,7 +348,7 @@ L 395.78 164.253516
 L 395.78 162.698608 
 L 353.93 162.698608 
 z
-" clip-path="url(#p0fea6b7162)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p0fea6b7162)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 81.905 225.923558 
@@ -1058,12 +1058,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
     <g id="text_7">
@@ -1179,7 +1179,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-36" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-36" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_24">
@@ -1194,7 +1194,7 @@ z
      <!-- c5 -->
      <g style="fill: #1a1a1a" transform="translate(97.98 50.601562) scale(0.1 -0.1)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-35" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-35" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_25">
@@ -1209,7 +1209,7 @@ z
      <!-- c4 -->
      <g style="fill: #1a1a1a" transform="translate(97.98 64.542187) scale(0.1 -0.1)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-34" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-34" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_26">
@@ -1252,7 +1252,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-33" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_27">
@@ -1267,7 +1267,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(155.420625 36.660937) scale(0.1 -0.1)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_28">
@@ -1282,7 +1282,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(155.420625 50.601562) scale(0.1 -0.1)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_29">
@@ -1297,7 +1297,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(155.420625 64.542187) scale(0.1 -0.1)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_30">
@@ -1431,11 +1431,11 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="83.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="133.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="188.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="238.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(83.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(133.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(188.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(238.999939 0)"/>
      </g>
     </g>
     <g id="patch_31">
@@ -1444,7 +1444,7 @@ L 204.86125 50.720312
 L 204.86125 43.720312 
 L 184.86125 43.720312 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_16">
      <!-- Model stat. unc. -->
@@ -1557,21 +1557,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -1616,9 +1616,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -1638,7 +1638,7 @@ L 102.83 272.370027
 L 102.83 271.679755 
 L 60.98 271.679755 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 102.83 272.24809 
@@ -1646,7 +1646,7 @@ L 144.68 272.24809
 L 144.68 271.801692 
 L 102.83 271.801692 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 144.68 272.247143 
@@ -1654,7 +1654,7 @@ L 186.53 272.247143
 L 186.53 271.802639 
 L 144.68 271.802639 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 186.53 272.607041 
@@ -1662,7 +1662,7 @@ L 228.38 272.607041
 L 228.38 271.442741 
 L 186.53 271.442741 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 228.38 272.527991 
@@ -1670,7 +1670,7 @@ L 270.23 272.527991
 L 270.23 271.521791 
 L 228.38 271.521791 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 270.23 272.254904 
@@ -1678,7 +1678,7 @@ L 312.08 272.254904
 L 312.08 271.794878 
 L 270.23 271.794878 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 312.08 272.205112 
@@ -1686,7 +1686,7 @@ L 353.93 272.205112
 L 353.93 271.84467 
 L 312.08 271.84467 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 353.93 272.340981 
@@ -1694,7 +1694,7 @@ L 395.78 272.340981
 L 395.78 271.708801 
 L 353.93 271.708801 
 z
-" clip-path="url(#pae2c404269)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pae2c404269)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 81.905 297.337967 
@@ -2171,7 +2171,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_examples_pull.svg
+++ b/docs/img/model_examples_pull.svg
@@ -652,7 +652,7 @@ L 77.957 213.488372
 L 77.957 213.345338 
 L 71.261 213.345338 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 77.957 213.397692 
@@ -660,7 +660,7 @@ L 84.653 213.397692
 L 84.653 213.149951 
 L 77.957 213.149951 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 84.653 213.118517 
@@ -668,7 +668,7 @@ L 91.349 213.118517
 L 91.349 212.713957 
 L 84.653 212.713957 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 91.349 212.81651 
@@ -676,7 +676,7 @@ L 98.045 212.81651
 L 98.045 212.300795 
 L 91.349 212.300795 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 98.045 211.929029 
@@ -684,7 +684,7 @@ L 104.741 211.929029
 L 104.741 211.185804 
 L 98.045 211.185804 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 104.741 210.683647 
@@ -692,7 +692,7 @@ L 111.437 210.683647
 L 111.437 209.713544 
 L 104.741 209.713544 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 111.437 208.541675 
@@ -700,7 +700,7 @@ L 118.133 208.541675
 L 118.133 207.278435 
 L 111.437 207.278435 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 118.133 203.224984 
@@ -708,7 +708,7 @@ L 124.829 203.224984
 L 124.829 201.438493 
 L 118.133 201.438493 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 124.829 195.700608 
@@ -716,7 +716,7 @@ L 131.525 195.700608
 L 131.525 193.372187 
 L 124.829 193.372187 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 131.525 189.795421 
@@ -724,7 +724,7 @@ L 138.221 189.795421
 L 138.221 187.119504 
 L 131.525 187.119504 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 138.221 169.456713 
@@ -732,7 +732,7 @@ L 144.917 169.456713
 L 144.917 165.835387 
 L 138.221 165.835387 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 144.917 155.065234 
@@ -740,7 +740,7 @@ L 151.613 155.065234
 L 151.613 150.904943 
 L 144.917 150.904943 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 151.613 132.823629 
@@ -748,7 +748,7 @@ L 158.309 132.823629
 L 158.309 127.947877 
 L 151.613 127.947877 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 158.309 110.818212 
@@ -756,7 +756,7 @@ L 165.005 110.818212
 L 165.005 105.326759 
 L 158.309 105.326759 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 165.005 89.13495 
@@ -764,7 +764,7 @@ L 171.701 89.13495
 L 171.701 83.098654 
 L 165.005 83.098654 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 171.701 74.713674 
@@ -772,7 +772,7 @@ L 178.397 74.713674
 L 178.397 68.341042 
 L 171.701 68.341042 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 178.397 66.721704 
@@ -780,7 +780,7 @@ L 185.093 66.721704
 L 185.093 60.170196 
 L 178.397 60.170196 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 185.093 66.155809 
@@ -788,7 +788,7 @@ L 191.789 66.155809
 L 191.789 59.591821 
 L 185.093 59.591821 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 191.789 75.137956 
@@ -796,7 +796,7 @@ L 198.485 75.137956
 L 198.485 68.774963 
 L 191.789 68.774963 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 198.485 81.925451 
@@ -804,7 +804,7 @@ L 205.181 81.925451
 L 205.181 75.718709 
 L 198.485 75.718709 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 205.181 91.325591 
@@ -812,7 +812,7 @@ L 211.877 91.325591
 L 211.877 85.34206 
 L 205.181 85.34206 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 211.877 97.896081 
@@ -820,7 +820,7 @@ L 218.573 97.896081
 L 218.573 92.073711 
 L 211.877 92.073711 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 218.573 111.94754 
@@ -828,7 +828,7 @@ L 225.269 111.94754
 L 225.269 106.485972 
 L 218.573 106.485972 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 225.269 107.147347 
@@ -836,7 +836,7 @@ L 231.965 107.147347
 L 231.965 101.559868 
 L 225.269 101.559868 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 231.965 109.971164 
@@ -844,7 +844,7 @@ L 238.661 109.971164
 L 238.661 104.457402 
 L 231.965 104.457402 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 238.661 108.206335 
@@ -852,7 +852,7 @@ L 245.357 108.206335
 L 245.357 102.646386 
 L 238.661 102.646386 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 245.357 116.675689 
@@ -860,7 +860,7 @@ L 252.053 116.675689
 L 252.053 111.341085 
 L 245.357 111.341085 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 252.053 127.678308 
@@ -868,7 +868,7 @@ L 258.749 127.678308
 L 258.749 122.651734 
 L 252.053 122.651734 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 258.749 137.473498 
@@ -876,7 +876,7 @@ L 265.445 137.473498
 L 265.445 132.738237 
 L 258.749 132.738237 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 265.445 148.87726 
@@ -884,7 +884,7 @@ L 272.141 148.87726
 L 272.141 144.505946 
 L 265.445 144.505946 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 272.141 158.859664 
@@ -892,7 +892,7 @@ L 278.837 158.859664
 L 278.837 154.834337 
 L 272.141 154.834337 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 278.837 176.461178 
@@ -900,7 +900,7 @@ L 285.533 176.461178
 L 285.533 173.134298 
 L 278.837 173.134298 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 285.533 187.357634 
@@ -908,7 +908,7 @@ L 292.229 187.357634
 L 292.229 184.551109 
 L 285.533 184.551109 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 292.229 196.255036 
@@ -916,7 +916,7 @@ L 298.925 196.255036
 L 298.925 193.96203 
 L 292.229 193.96203 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 298.925 202.125403 
@@ -924,7 +924,7 @@ L 305.621 202.125403
 L 305.621 200.249533 
 L 298.925 200.249533 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 305.621 206.915935 
@@ -932,7 +932,7 @@ L 312.317 206.915935
 L 312.317 205.471365 
 L 305.621 205.471365 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 312.317 209.818208 
@@ -940,7 +940,7 @@ L 319.013 209.818208
 L 319.013 208.719544 
 L 312.317 208.719544 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 319.013 211.669538 
@@ -948,7 +948,7 @@ L 325.709 211.669538
 L 325.709 210.87316 
 L 319.013 210.87316 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 325.709 212.250445 
@@ -956,7 +956,7 @@ L 332.405 212.250445
 L 332.405 211.579557 
 L 325.709 211.579557 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 332.405 213.17697 
@@ -964,7 +964,7 @@ L 339.101 213.17697
 L 339.101 212.798538 
 L 332.405 212.798538 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 339.101 213.234451 
@@ -972,7 +972,7 @@ L 345.797 213.234451
 L 345.797 212.884091 
 L 339.101 212.884091 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 345.797 213.446478 
@@ -980,7 +980,7 @@ L 352.493 213.446478
 L 352.493 213.244198 
 L 345.797 213.244198 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 352.493 213.488372 
@@ -988,7 +988,7 @@ L 359.189 213.488372
 L 359.189 213.345338 
 L 352.493 213.345338 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 359.189 213.488372 
@@ -996,7 +996,7 @@ L 365.885 213.488372
 L 365.885 213.345338 
 L 359.189 213.345338 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 365.885 213.488372 
@@ -1004,7 +1004,7 @@ L 372.581 213.488372
 L 372.581 213.488372 
 L 365.885 213.488372 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 372.581 213.488372 
@@ -1012,7 +1012,7 @@ L 379.277 213.488372
 L 379.277 213.345338 
 L 372.581 213.345338 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 379.277 213.488372 
@@ -1020,7 +1020,7 @@ L 385.973 213.488372
 L 385.973 213.345338 
 L 379.277 213.345338 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 385.973 213.488372 
@@ -1028,7 +1028,7 @@ L 392.669 213.488372
 L 392.669 213.488372 
 L 385.973 213.488372 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 392.669 213.488372 
@@ -1036,7 +1036,7 @@ L 399.365 213.488372
 L 399.365 213.488372 
 L 392.669 213.488372 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 399.365 213.488372 
@@ -1044,7 +1044,7 @@ L 406.061 213.488372
 L 406.061 213.488372 
 L 399.365 213.488372 
 z
-" clip-path="url(#p83c8b15f2d)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p83c8b15f2d)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 74.609 213.451269 
@@ -2134,7 +2134,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(309.5435 26.4) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_61">
@@ -2168,7 +2168,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_62">
@@ -2183,7 +2183,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(309.5435 59.8575) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -2192,7 +2192,7 @@ L 299.9435 76.58625
 L 299.9435 68.18625 
 L 275.9435 68.18625 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_10">
      <!-- Model stat. unc. -->
@@ -2291,21 +2291,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2350,9 +2350,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -3152,7 +3152,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_examples_pull_no_model_unc.svg
+++ b/docs/img/model_examples_pull_no_model_unc.svg
@@ -2403,7 +2403,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(353.8665 39.262884) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_11">
@@ -2418,7 +2418,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(353.8665 55.991634) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_12">
@@ -2433,7 +2433,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(353.8665 72.720384) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2508,9 +2508,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/model_examples_stacked.svg
+++ b/docs/img/model_examples_stacked.svg
@@ -652,7 +652,7 @@ L 70.976 228.991256
 L 70.976 228.850214 
 L 64.28 228.850214 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 70.976 228.901839 
@@ -660,7 +660,7 @@ L 77.672 228.901839
 L 77.672 228.657547 
 L 70.976 228.657547 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 77.672 228.626552 
@@ -668,7 +668,7 @@ L 84.368 228.626552
 L 84.368 228.227625 
 L 77.672 228.227625 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 84.368 228.328751 
@@ -676,7 +676,7 @@ L 91.064 228.328751
 L 91.064 227.820217 
 L 84.368 227.820217 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 91.064 227.453629 
@@ -684,7 +684,7 @@ L 97.76 227.453629
 L 97.76 226.720754 
 L 91.064 226.720754 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 97.76 226.22559 
@@ -692,7 +692,7 @@ L 104.456 226.22559
 L 104.456 225.268998 
 L 97.76 225.268998 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 104.456 224.113449 
@@ -700,7 +700,7 @@ L 111.152 224.113449
 L 111.152 222.867802 
 L 104.456 222.867802 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 111.152 218.870801 
@@ -708,7 +708,7 @@ L 117.848 218.870801
 L 117.848 217.109189 
 L 111.152 217.109189 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 117.848 211.451214 
@@ -716,7 +716,7 @@ L 124.544 211.451214
 L 124.544 209.15522 
 L 117.848 209.15522 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 124.544 205.628265 
@@ -724,7 +724,7 @@ L 131.24 205.628265
 L 131.24 202.989615 
 L 124.544 202.989615 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 131.24 185.572804 
@@ -732,7 +732,7 @@ L 137.936 185.572804
 L 137.936 182.001911 
 L 131.24 182.001911 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 137.936 171.381749 
@@ -740,7 +740,7 @@ L 144.632 171.381749
 L 144.632 167.279396 
 L 137.936 167.279396 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 144.632 149.449892 
@@ -748,7 +748,7 @@ L 151.328 149.449892
 L 151.328 144.642042 
 L 144.632 144.642042 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 151.328 127.750934 
@@ -756,7 +756,7 @@ L 158.024 127.750934
 L 158.024 122.335958 
 L 151.328 122.335958 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 158.024 106.369645 
@@ -764,7 +764,7 @@ L 164.72 106.369645
 L 164.72 100.417413 
 L 158.024 100.417413 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 164.72 92.149207 
@@ -772,7 +772,7 @@ L 171.416 92.149207
 L 171.416 85.865323 
 L 164.72 85.865323 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 171.416 84.268537 
@@ -780,7 +780,7 @@ L 178.112 84.268537
 L 178.112 77.808268 
 L 171.416 77.808268 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 178.112 83.710523 
@@ -788,7 +788,7 @@ L 184.808 83.710523
 L 184.808 77.237949 
 L 178.112 77.237949 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 184.808 92.56758 
@@ -796,7 +796,7 @@ L 191.504 92.56758
 L 191.504 86.293201 
 L 184.808 86.293201 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 191.504 99.260549 
@@ -804,7 +804,7 @@ L 198.2 99.260549
 L 198.2 93.140245 
 L 191.504 93.140245 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 198.2 108.529778 
@@ -812,7 +812,7 @@ L 204.896 108.529778
 L 204.896 102.629576 
 L 198.2 102.629576 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 204.896 115.008763 
@@ -820,7 +820,7 @@ L 211.592 115.008763
 L 211.592 109.267478 
 L 204.896 109.267478 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 211.592 128.864534 
@@ -828,7 +828,7 @@ L 218.288 128.864534
 L 218.288 123.479027 
 L 211.592 123.479027 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 218.288 124.131191 
@@ -836,7 +836,7 @@ L 224.984 124.131191
 L 224.984 118.621527 
 L 218.288 118.621527 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 224.984 126.915682 
@@ -844,7 +844,7 @@ L 231.68 126.915682
 L 231.68 121.478708 
 L 224.984 121.478708 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 231.68 125.175432 
@@ -852,7 +852,7 @@ L 238.376 125.175432
 L 238.376 119.692913 
 L 231.68 119.692913 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 238.376 133.526836 
@@ -860,7 +860,7 @@ L 245.072 133.526836
 L 245.072 128.266525 
 L 238.376 128.266525 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 245.072 144.376227 
@@ -868,7 +868,7 @@ L 251.768 144.376227
 L 251.768 139.419656 
 L 245.072 139.419656 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 251.768 154.035004 
@@ -876,7 +876,7 @@ L 258.464 154.035004
 L 258.464 149.36569 
 L 251.768 149.36569 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 258.464 165.279952 
@@ -884,7 +884,7 @@ L 265.16 165.279952
 L 265.16 160.969515 
 L 258.464 160.969515 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 265.16 175.123335 
@@ -892,7 +892,7 @@ L 271.856 175.123335
 L 271.856 171.154067 
 L 265.16 171.154067 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 271.856 192.479722 
@@ -900,7 +900,7 @@ L 278.552 192.479722
 L 278.552 189.199173 
 L 271.856 189.199173 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 278.552 203.224428 
@@ -908,7 +908,7 @@ L 285.248 203.224428
 L 285.248 200.456988 
 L 278.552 200.456988 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 285.248 211.99792 
@@ -916,7 +916,7 @@ L 291.944 211.99792
 L 291.944 209.736848 
 L 285.248 209.736848 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 291.944 217.786534 
@@ -924,7 +924,7 @@ L 298.64 217.786534
 L 298.64 215.936788 
 L 291.944 215.936788 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 298.64 222.51035 
@@ -932,7 +932,7 @@ L 305.336 222.51035
 L 305.336 221.085898 
 L 298.64 221.085898 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 305.336 225.372204 
@@ -940,7 +940,7 @@ L 312.032 225.372204
 L 312.032 224.288841 
 L 305.336 224.288841 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 312.032 227.197752 
@@ -948,7 +948,7 @@ L 318.728 227.197752
 L 318.728 226.412464 
 L 312.032 226.412464 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 318.728 227.770568 
@@ -956,7 +956,7 @@ L 325.424 227.770568
 L 325.424 227.109024 
 L 318.728 227.109024 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 325.424 228.68419 
@@ -964,7 +964,7 @@ L 332.12 228.68419
 L 332.12 228.311029 
 L 325.424 228.311029 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 332.12 228.740871 
@@ -972,7 +972,7 @@ L 338.816 228.740871
 L 338.816 228.39539 
 L 332.12 228.39539 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 338.816 228.949946 
@@ -980,7 +980,7 @@ L 345.512 228.949946
 L 345.512 228.750482 
 L 338.816 228.750482 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 345.512 228.991256 
@@ -988,7 +988,7 @@ L 352.208 228.991256
 L 352.208 228.850214 
 L 345.512 228.850214 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 352.208 228.991256 
@@ -996,7 +996,7 @@ L 358.904 228.991256
 L 358.904 228.850214 
 L 352.208 228.850214 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 358.904 228.991256 
@@ -1004,7 +1004,7 @@ L 365.6 228.991256
 L 365.6 228.991256 
 L 358.904 228.991256 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 365.6 228.991256 
@@ -1012,7 +1012,7 @@ L 372.296 228.991256
 L 372.296 228.850214 
 L 365.6 228.850214 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 372.296 228.991256 
@@ -1020,7 +1020,7 @@ L 378.992 228.991256
 L 378.992 228.850214 
 L 372.296 228.850214 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 378.992 228.991256 
@@ -1028,7 +1028,7 @@ L 385.688 228.991256
 L 385.688 228.991256 
 L 378.992 228.991256 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 385.688 228.991256 
@@ -1036,7 +1036,7 @@ L 392.384 228.991256
 L 392.384 228.991256 
 L 385.688 228.991256 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 392.384 228.991256 
@@ -1044,7 +1044,7 @@ L 399.08 228.991256
 L 399.08 228.991256 
 L 392.384 228.991256 
 z
-" clip-path="url(#pe8649ff4e5)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pe8649ff4e5)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_1">
     <path d="M 67.628 228.954669 
@@ -2043,12 +2043,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2924,7 +2924,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_62">
@@ -2939,7 +2939,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(302.5625 58.631634) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -2954,7 +2954,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(302.5625 75.360384) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_64">
@@ -3088,11 +3088,11 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="83.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="133.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="188.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="238.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(83.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(133.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(188.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(238.999939 0)"/>
      </g>
     </g>
     <g id="patch_65">
@@ -3101,7 +3101,7 @@ L 292.9625 109.020384
 L 292.9625 100.620384 
 L 268.9625 100.620384 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_12">
      <!-- Model stat. unc. -->
@@ -3220,21 +3220,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -3279,9 +3279,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -3301,7 +3301,7 @@ L 70.976 299.902884
 L 70.976 248.330791 
 L 64.28 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_68">
     <path d="M 70.976 289.004418 
@@ -3309,7 +3309,7 @@ L 77.672 289.004418
 L 77.672 259.229256 
 L 70.976 259.229256 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_69">
     <path d="M 77.672 283.233581 
@@ -3317,7 +3317,7 @@ L 84.368 283.233581
 L 84.368 265.000093 
 L 77.672 265.000093 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_70">
     <path d="M 84.368 281.2686 
@@ -3325,7 +3325,7 @@ L 91.064 281.2686
 L 91.064 266.965075 
 L 84.368 266.965075 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_71">
     <path d="M 91.064 279.079364 
@@ -3333,7 +3333,7 @@ L 97.76 279.079364
 L 97.76 269.15431 
 L 91.064 269.15431 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_72">
     <path d="M 97.76 277.918782 
@@ -3341,7 +3341,7 @@ L 104.456 277.918782
 L 104.456 270.314892 
 L 97.76 270.314892 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_73">
     <path d="M 104.456 277.036532 
@@ -3349,7 +3349,7 @@ L 111.152 277.036532
 L 111.152 271.197142 
 L 104.456 271.197142 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_74">
     <path d="M 111.152 276.181373 
@@ -3357,7 +3357,7 @@ L 117.848 276.181373
 L 117.848 272.052301 
 L 111.152 272.052301 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_75">
     <path d="M 117.848 275.700861 
@@ -3365,7 +3365,7 @@ L 124.544 275.700861
 L 124.544 272.532813 
 L 117.848 272.532813 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_76">
     <path d="M 124.544 275.495159 
@@ -3373,7 +3373,7 @@ L 131.24 275.495159
 L 131.24 272.738515 
 L 124.544 272.738515 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_77">
     <path d="M 131.24 275.135325 
@@ -3381,7 +3381,7 @@ L 137.936 275.135325
 L 137.936 273.09835 
 L 131.24 273.09835 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_78">
     <path d="M 137.936 275.00338 
@@ -3389,7 +3389,7 @@ L 144.632 275.00338
 L 144.632 273.230295 
 L 137.936 273.230295 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_79">
     <path d="M 144.632 274.87329 
@@ -3397,7 +3397,7 @@ L 151.328 274.87329
 L 151.328 273.360385 
 L 144.632 273.360385 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_80">
     <path d="M 151.328 274.788476 
@@ -3405,7 +3405,7 @@ L 158.024 274.788476
 L 158.024 273.445198 
 L 151.328 273.445198 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_81">
     <path d="M 158.024 274.727854 
@@ -3413,7 +3413,7 @@ L 164.72 274.727854
 L 164.72 273.505821 
 L 158.024 273.505821 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_82">
     <path d="M 164.72 274.695605 
@@ -3421,7 +3421,7 @@ L 171.416 274.695605
 L 171.416 273.538069 
 L 164.72 273.538069 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_83">
     <path d="M 171.416 274.679803 
@@ -3429,7 +3429,7 @@ L 178.112 274.679803
 L 178.112 273.553871 
 L 171.416 273.553871 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_84">
     <path d="M 178.112 274.678733 
@@ -3437,7 +3437,7 @@ L 184.808 274.678733
 L 184.808 273.554942 
 L 178.112 273.554942 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_85">
     <path d="M 184.808 274.696482 
@@ -3445,7 +3445,7 @@ L 191.504 274.696482
 L 191.504 273.537193 
 L 184.808 273.537193 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_86">
     <path d="M 191.504 274.711074 
@@ -3453,7 +3453,7 @@ L 198.2 274.711074
 L 198.2 273.5226 
 L 191.504 273.5226 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_87">
     <path d="M 198.2 274.733242 
@@ -3461,7 +3461,7 @@ L 204.896 274.733242
 L 204.896 273.500433 
 L 198.2 273.500433 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_88">
     <path d="M 204.896 274.750303 
@@ -3469,7 +3469,7 @@ L 211.592 274.750303
 L 211.592 273.483371 
 L 204.896 273.483371 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_89">
     <path d="M 211.592 274.792152 
@@ -3477,7 +3477,7 @@ L 218.288 274.792152
 L 218.288 273.441523 
 L 211.592 273.441523 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_90">
     <path d="M 218.288 274.776934 
@@ -3485,7 +3485,7 @@ L 224.984 274.776934
 L 224.984 273.456741 
 L 218.288 273.456741 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_91">
     <path d="M 224.984 274.785759 
@@ -3493,7 +3493,7 @@ L 231.68 274.785759
 L 231.68 273.447915 
 L 224.984 273.447915 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_92">
     <path d="M 231.68 274.780202 
@@ -3501,7 +3501,7 @@ L 238.376 274.780202
 L 238.376 273.453472 
 L 231.68 273.453472 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_93">
     <path d="M 238.376 274.808224 
@@ -3509,7 +3509,7 @@ L 245.072 274.808224
 L 245.072 273.42545 
 L 238.376 273.42545 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_94">
     <path d="M 245.072 274.850593 
@@ -3517,7 +3517,7 @@ L 251.768 274.850593
 L 251.768 273.383082 
 L 245.072 273.383082 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_95">
     <path d="M 251.768 274.895733 
@@ -3525,7 +3525,7 @@ L 258.464 274.895733
 L 258.464 273.337941 
 L 251.768 273.337941 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_96">
     <path d="M 258.464 274.960582 
@@ -3533,7 +3533,7 @@ L 265.16 274.960582
 L 265.16 273.273092 
 L 258.464 273.273092 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_97">
     <path d="M 265.16 275.033104 
@@ -3541,7 +3541,7 @@ L 271.856 275.033104
 L 271.856 273.20057 
 L 265.16 273.20057 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_98">
     <path d="M 271.856 275.225466 
@@ -3549,7 +3549,7 @@ L 278.552 275.225466
 L 278.552 273.008208 
 L 271.856 273.008208 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_99">
     <path d="M 278.552 275.431016 
@@ -3557,7 +3557,7 @@ L 285.248 275.431016
 L 285.248 272.802659 
 L 278.552 272.802659 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_100">
     <path d="M 285.248 275.725327 
@@ -3565,7 +3565,7 @@ L 291.944 275.725327
 L 291.944 272.508348 
 L 285.248 272.508348 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_101">
     <path d="M 291.944 276.083005 
@@ -3573,7 +3573,7 @@ L 298.64 276.083005
 L 298.64 272.15067 
 L 291.944 272.15067 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_102">
     <path d="M 298.64 276.670036 
@@ -3581,7 +3581,7 @@ L 305.336 276.670036
 L 305.336 271.563638 
 L 298.64 271.563638 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_103">
     <path d="M 305.336 277.473895 
@@ -3589,7 +3589,7 @@ L 312.032 277.473895
 L 312.032 270.75978 
 L 305.336 270.75978 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_104">
     <path d="M 312.032 278.748148 
@@ -3597,7 +3597,7 @@ L 318.728 278.748148
 L 318.728 269.485527 
 L 312.032 269.485527 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_105">
     <path d="M 318.728 279.614441 
@@ -3605,7 +3605,7 @@ L 325.424 279.614441
 L 325.424 268.619234 
 L 318.728 268.619234 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_106">
     <path d="M 325.424 283.863047 
@@ -3613,7 +3613,7 @@ L 332.12 283.863047
 L 332.12 264.370628 
 L 325.424 264.370628 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_107">
     <path d="M 332.12 284.643947 
@@ -3621,7 +3621,7 @@ L 338.816 284.643947
 L 338.816 263.589728 
 L 332.12 263.589728 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_108">
     <path d="M 338.816 292.350326 
@@ -3629,7 +3629,7 @@ L 345.512 292.350326
 L 345.512 255.883349 
 L 338.816 255.883349 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_109">
     <path d="M 345.512 299.902884 
@@ -3637,7 +3637,7 @@ L 352.208 299.902884
 L 352.208 248.330791 
 L 345.512 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_110">
     <path d="M 352.208 299.902884 
@@ -3645,7 +3645,7 @@ L 358.904 299.902884
 L 358.904 248.330791 
 L 352.208 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_111">
     <path d="M 358.904 299.902884 
@@ -3653,7 +3653,7 @@ L 365.6 299.902884
 L 365.6 248.330791 
 L 358.904 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_112">
     <path d="M 365.6 299.902884 
@@ -3661,7 +3661,7 @@ L 372.296 299.902884
 L 372.296 248.330791 
 L 365.6 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_113">
     <path d="M 372.296 299.902884 
@@ -3669,7 +3669,7 @@ L 378.992 299.902884
 L 378.992 248.330791 
 L 372.296 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_114">
     <path d="M 378.992 299.902884 
@@ -3677,7 +3677,7 @@ L 385.688 299.902884
 L 385.688 248.330791 
 L 378.992 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_115">
     <path d="M 385.688 299.902884 
@@ -3685,7 +3685,7 @@ L 392.384 299.902884
 L 392.384 248.330791 
 L 385.688 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_116">
     <path d="M 392.384 299.902884 
@@ -3693,7 +3693,7 @@ L 399.08 299.902884
 L 399.08 248.330791 
 L 392.384 248.330791 
 z
-" clip-path="url(#pea285079fb)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pea285079fb)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 67.628 286.524923 
@@ -4157,15 +4157,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -4280,7 +4280,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_examples_stacked_unstacked.svg
+++ b/docs/img/model_examples_stacked_unstacked.svg
@@ -448,7 +448,7 @@ L 70.976 213.488372
 L 70.976 213.345338 
 L 64.28 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_6">
     <path d="M 70.976 213.397692 
@@ -456,7 +456,7 @@ L 77.672 213.397692
 L 77.672 213.149951 
 L 70.976 213.149951 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 77.672 213.118517 
@@ -464,7 +464,7 @@ L 84.368 213.118517
 L 84.368 212.713957 
 L 77.672 212.713957 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 84.368 212.81651 
@@ -472,7 +472,7 @@ L 91.064 212.81651
 L 91.064 212.300795 
 L 84.368 212.300795 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 91.064 211.929029 
@@ -480,7 +480,7 @@ L 97.76 211.929029
 L 97.76 211.185804 
 L 91.064 211.185804 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 97.76 210.683647 
@@ -488,7 +488,7 @@ L 104.456 210.683647
 L 104.456 209.713544 
 L 97.76 209.713544 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 104.456 208.541675 
@@ -496,7 +496,7 @@ L 111.152 208.541675
 L 111.152 207.278435 
 L 104.456 207.278435 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 111.152 203.224984 
@@ -504,7 +504,7 @@ L 117.848 203.224984
 L 117.848 201.438493 
 L 111.152 201.438493 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 117.848 195.700608 
@@ -512,7 +512,7 @@ L 124.544 195.700608
 L 124.544 193.372187 
 L 117.848 193.372187 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 124.544 189.795421 
@@ -520,7 +520,7 @@ L 131.24 189.795421
 L 131.24 187.119504 
 L 124.544 187.119504 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 131.24 169.456713 
@@ -528,7 +528,7 @@ L 137.936 169.456713
 L 137.936 165.835387 
 L 131.24 165.835387 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 137.936 155.065234 
@@ -536,7 +536,7 @@ L 144.632 155.065234
 L 144.632 150.904943 
 L 137.936 150.904943 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 144.632 132.823629 
@@ -544,7 +544,7 @@ L 151.328 132.823629
 L 151.328 127.947877 
 L 144.632 127.947877 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 151.328 110.818212 
@@ -552,7 +552,7 @@ L 158.024 110.818212
 L 158.024 105.326759 
 L 151.328 105.326759 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 158.024 89.13495 
@@ -560,7 +560,7 @@ L 164.72 89.13495
 L 164.72 83.098654 
 L 158.024 83.098654 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 164.72 74.713674 
@@ -568,7 +568,7 @@ L 171.416 74.713674
 L 171.416 68.341042 
 L 164.72 68.341042 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 171.416 66.721704 
@@ -576,7 +576,7 @@ L 178.112 66.721704
 L 178.112 60.170196 
 L 171.416 60.170196 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 178.112 66.155809 
@@ -584,7 +584,7 @@ L 184.808 66.155809
 L 184.808 59.591821 
 L 178.112 59.591821 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 184.808 75.137956 
@@ -592,7 +592,7 @@ L 191.504 75.137956
 L 191.504 68.774963 
 L 184.808 68.774963 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 191.504 81.925451 
@@ -600,7 +600,7 @@ L 198.2 81.925451
 L 198.2 75.718709 
 L 191.504 75.718709 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 198.2 91.325591 
@@ -608,7 +608,7 @@ L 204.896 91.325591
 L 204.896 85.34206 
 L 198.2 85.34206 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 204.896 97.896081 
@@ -616,7 +616,7 @@ L 211.592 97.896081
 L 211.592 92.073711 
 L 204.896 92.073711 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 211.592 111.94754 
@@ -624,7 +624,7 @@ L 218.288 111.94754
 L 218.288 106.485972 
 L 211.592 106.485972 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 218.288 107.147347 
@@ -632,7 +632,7 @@ L 224.984 107.147347
 L 224.984 101.559868 
 L 218.288 101.559868 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 224.984 109.971164 
@@ -640,7 +640,7 @@ L 231.68 109.971164
 L 231.68 104.457402 
 L 224.984 104.457402 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 231.68 108.206335 
@@ -648,7 +648,7 @@ L 238.376 108.206335
 L 238.376 102.646386 
 L 231.68 102.646386 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 238.376 116.675689 
@@ -656,7 +656,7 @@ L 245.072 116.675689
 L 245.072 111.341085 
 L 238.376 111.341085 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 245.072 127.678308 
@@ -664,7 +664,7 @@ L 251.768 127.678308
 L 251.768 122.651734 
 L 245.072 122.651734 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 251.768 137.473498 
@@ -672,7 +672,7 @@ L 258.464 137.473498
 L 258.464 132.738237 
 L 251.768 132.738237 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 258.464 148.87726 
@@ -680,7 +680,7 @@ L 265.16 148.87726
 L 265.16 144.505946 
 L 258.464 144.505946 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 265.16 158.859664 
@@ -688,7 +688,7 @@ L 271.856 158.859664
 L 271.856 154.834337 
 L 265.16 154.834337 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 271.856 176.461178 
@@ -696,7 +696,7 @@ L 278.552 176.461178
 L 278.552 173.134298 
 L 271.856 173.134298 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 278.552 187.357634 
@@ -704,7 +704,7 @@ L 285.248 187.357634
 L 285.248 184.551109 
 L 278.552 184.551109 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 285.248 196.255036 
@@ -712,7 +712,7 @@ L 291.944 196.255036
 L 291.944 193.96203 
 L 285.248 193.96203 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 291.944 202.125403 
@@ -720,7 +720,7 @@ L 298.64 202.125403
 L 298.64 200.249533 
 L 291.944 200.249533 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 298.64 206.915935 
@@ -728,7 +728,7 @@ L 305.336 206.915935
 L 305.336 205.471365 
 L 298.64 205.471365 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 305.336 209.818208 
@@ -736,7 +736,7 @@ L 312.032 209.818208
 L 312.032 208.719544 
 L 305.336 208.719544 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 312.032 211.669538 
@@ -744,7 +744,7 @@ L 318.728 211.669538
 L 318.728 210.87316 
 L 312.032 210.87316 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 318.728 212.250445 
@@ -752,7 +752,7 @@ L 325.424 212.250445
 L 325.424 211.579557 
 L 318.728 211.579557 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 325.424 213.17697 
@@ -760,7 +760,7 @@ L 332.12 213.17697
 L 332.12 212.798538 
 L 325.424 212.798538 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 332.12 213.234451 
@@ -768,7 +768,7 @@ L 338.816 213.234451
 L 338.816 212.884091 
 L 332.12 212.884091 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 338.816 213.446478 
@@ -776,7 +776,7 @@ L 345.512 213.446478
 L 345.512 213.244198 
 L 338.816 213.244198 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 345.512 213.488372 
@@ -784,7 +784,7 @@ L 352.208 213.488372
 L 352.208 213.345338 
 L 345.512 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 352.208 213.488372 
@@ -792,7 +792,7 @@ L 358.904 213.488372
 L 358.904 213.345338 
 L 352.208 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 358.904 213.488372 
@@ -800,7 +800,7 @@ L 365.6 213.488372
 L 365.6 213.488372 
 L 358.904 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 365.6 213.488372 
@@ -808,7 +808,7 @@ L 372.296 213.488372
 L 372.296 213.345338 
 L 365.6 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 372.296 213.488372 
@@ -816,7 +816,7 @@ L 378.992 213.488372
 L 378.992 213.345338 
 L 372.296 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 378.992 213.488372 
@@ -824,7 +824,7 @@ L 385.688 213.488372
 L 385.688 213.488372 
 L 378.992 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 385.688 213.488372 
@@ -832,7 +832,7 @@ L 392.384 213.488372
 L 392.384 213.488372 
 L 385.688 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 392.384 213.488372 
@@ -840,7 +840,7 @@ L 399.08 213.488372
 L 399.08 213.488372 
 L 392.384 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 64.28 213.488372 
@@ -1944,12 +1944,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2001,7 +2001,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_62">
@@ -2016,7 +2016,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(302.5625 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -2032,7 +2032,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(302.5625 59.8575) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_64">
@@ -2147,10 +2147,10 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
      </g>
     </g>
     <g id="patch_65">
@@ -2159,7 +2159,7 @@ L 292.9625 93.315
 L 292.9625 84.915 
 L 268.9625 84.915 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_11">
      <!-- Model stat. unc. -->
@@ -2226,21 +2226,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2285,9 +2285,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -2307,7 +2307,7 @@ L 70.976 310.186047
 L 70.976 207.04186 
 L 64.28 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_68">
     <path d="M 70.976 288.389115 
@@ -2315,7 +2315,7 @@ L 77.672 288.389115
 L 77.672 228.838792 
 L 70.976 228.838792 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_69">
     <path d="M 77.672 276.847442 
@@ -2323,7 +2323,7 @@ L 84.368 276.847442
 L 84.368 240.380465 
 L 77.672 240.380465 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_70">
     <path d="M 84.368 272.917479 
@@ -2331,7 +2331,7 @@ L 91.064 272.917479
 L 91.064 244.310428 
 L 84.368 244.310428 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_71">
     <path d="M 91.064 268.539007 
@@ -2339,7 +2339,7 @@ L 97.76 268.539007
 L 97.76 248.6889 
 L 91.064 248.6889 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_72">
     <path d="M 97.76 266.217844 
@@ -2347,7 +2347,7 @@ L 104.456 266.217844
 L 104.456 251.010063 
 L 97.76 251.010063 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_73">
     <path d="M 104.456 264.453343 
@@ -2355,7 +2355,7 @@ L 111.152 264.453343
 L 111.152 252.774564 
 L 104.456 252.774564 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_74">
     <path d="M 111.152 262.743026 
@@ -2363,7 +2363,7 @@ L 117.848 262.743026
 L 117.848 254.484881 
 L 111.152 254.484881 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_75">
     <path d="M 117.848 261.782002 
@@ -2371,7 +2371,7 @@ L 124.544 261.782002
 L 124.544 255.445905 
 L 117.848 255.445905 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_76">
     <path d="M 124.544 261.370598 
@@ -2379,7 +2379,7 @@ L 131.24 261.370598
 L 131.24 255.857309 
 L 124.544 255.857309 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_77">
     <path d="M 131.24 260.650929 
@@ -2387,7 +2387,7 @@ L 137.936 260.650929
 L 137.936 256.576978 
 L 131.24 256.576978 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_78">
     <path d="M 137.936 260.387039 
@@ -2395,7 +2395,7 @@ L 144.632 260.387039
 L 144.632 256.840868 
 L 137.936 256.840868 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_79">
     <path d="M 144.632 260.126859 
@@ -2403,7 +2403,7 @@ L 151.328 260.126859
 L 151.328 257.101048 
 L 144.632 257.101048 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_80">
     <path d="M 151.328 259.957232 
@@ -2411,7 +2411,7 @@ L 158.024 259.957232
 L 158.024 257.270675 
 L 151.328 257.270675 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_81">
     <path d="M 158.024 259.835986 
@@ -2419,7 +2419,7 @@ L 164.72 259.835986
 L 164.72 257.391921 
 L 158.024 257.391921 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_82">
     <path d="M 164.72 259.771489 
@@ -2427,7 +2427,7 @@ L 171.416 259.771489
 L 171.416 257.456418 
 L 164.72 257.456418 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_83">
     <path d="M 171.416 259.739885 
@@ -2435,7 +2435,7 @@ L 178.112 259.739885
 L 178.112 257.488022 
 L 171.416 257.488022 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_84">
     <path d="M 178.112 259.737745 
@@ -2443,7 +2443,7 @@ L 184.808 259.737745
 L 184.808 257.490162 
 L 178.112 257.490162 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_85">
     <path d="M 184.808 259.773243 
@@ -2451,7 +2451,7 @@ L 191.504 259.773243
 L 191.504 257.454664 
 L 184.808 257.454664 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_86">
     <path d="M 191.504 259.802427 
@@ -2459,7 +2459,7 @@ L 198.2 259.802427
 L 198.2 257.42548 
 L 191.504 257.42548 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_87">
     <path d="M 198.2 259.846762 
@@ -2467,7 +2467,7 @@ L 204.896 259.846762
 L 204.896 257.381145 
 L 198.2 257.381145 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_88">
     <path d="M 204.896 259.880886 
@@ -2475,7 +2475,7 @@ L 211.592 259.880886
 L 211.592 257.347021 
 L 204.896 257.347021 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_89">
     <path d="M 211.592 259.964582 
@@ -2483,7 +2483,7 @@ L 218.288 259.964582
 L 218.288 257.263325 
 L 211.592 257.263325 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_90">
     <path d="M 218.288 259.934147 
@@ -2491,7 +2491,7 @@ L 224.984 259.934147
 L 224.984 257.29376 
 L 218.288 257.29376 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_91">
     <path d="M 224.984 259.951797 
@@ -2499,7 +2499,7 @@ L 231.68 259.951797
 L 231.68 257.27611 
 L 224.984 257.27611 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_92">
     <path d="M 231.68 259.940683 
@@ -2507,7 +2507,7 @@ L 238.376 259.940683
 L 238.376 257.287224 
 L 231.68 257.287224 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_93">
     <path d="M 238.376 259.996727 
@@ -2515,7 +2515,7 @@ L 245.072 259.996727
 L 245.072 257.23118 
 L 238.376 257.23118 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_94">
     <path d="M 245.072 260.081464 
@@ -2523,7 +2523,7 @@ L 251.768 260.081464
 L 251.768 257.146443 
 L 245.072 257.146443 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_95">
     <path d="M 251.768 260.171746 
@@ -2531,7 +2531,7 @@ L 258.464 260.171746
 L 258.464 257.056161 
 L 251.768 257.056161 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_96">
     <path d="M 258.464 260.301444 
@@ -2539,7 +2539,7 @@ L 265.16 260.301444
 L 265.16 256.926463 
 L 258.464 256.926463 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_97">
     <path d="M 265.16 260.446488 
@@ -2547,7 +2547,7 @@ L 271.856 260.446488
 L 271.856 256.781419 
 L 265.16 256.781419 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_98">
     <path d="M 271.856 260.831211 
@@ -2555,7 +2555,7 @@ L 278.552 260.831211
 L 278.552 256.396696 
 L 271.856 256.396696 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_99">
     <path d="M 278.552 261.242311 
@@ -2563,7 +2563,7 @@ L 285.248 261.242311
 L 285.248 255.985596 
 L 278.552 255.985596 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_100">
     <path d="M 285.248 261.830932 
@@ -2571,7 +2571,7 @@ L 291.944 261.830932
 L 291.944 255.396975 
 L 285.248 255.396975 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_101">
     <path d="M 291.944 262.546289 
@@ -2579,7 +2579,7 @@ L 298.64 262.546289
 L 298.64 254.681618 
 L 291.944 254.681618 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_102">
     <path d="M 298.64 263.720352 
@@ -2587,7 +2587,7 @@ L 305.336 263.720352
 L 305.336 253.507555 
 L 298.64 253.507555 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_103">
     <path d="M 305.336 265.328068 
@@ -2595,7 +2595,7 @@ L 312.032 265.328068
 L 312.032 251.899839 
 L 305.336 251.899839 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_104">
     <path d="M 312.032 267.876575 
@@ -2603,7 +2603,7 @@ L 318.728 267.876575
 L 318.728 249.351332 
 L 312.032 249.351332 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_105">
     <path d="M 318.728 269.609161 
@@ -2611,7 +2611,7 @@ L 325.424 269.609161
 L 325.424 247.618746 
 L 318.728 247.618746 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_106">
     <path d="M 325.424 278.106372 
@@ -2619,7 +2619,7 @@ L 332.12 278.106372
 L 332.12 239.121535 
 L 325.424 239.121535 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_107">
     <path d="M 332.12 279.668172 
@@ -2627,7 +2627,7 @@ L 338.816 279.668172
 L 338.816 237.559735 
 L 332.12 237.559735 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_108">
     <path d="M 338.816 295.08093 
@@ -2635,7 +2635,7 @@ L 345.512 295.08093
 L 345.512 222.146977 
 L 338.816 222.146977 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_109">
     <path d="M 345.512 310.186047 
@@ -2643,7 +2643,7 @@ L 352.208 310.186047
 L 352.208 207.04186 
 L 345.512 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_110">
     <path d="M 352.208 310.186047 
@@ -2651,7 +2651,7 @@ L 358.904 310.186047
 L 358.904 207.04186 
 L 352.208 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_111">
     <path d="M 358.904 284.4 
@@ -2659,7 +2659,7 @@ L 365.6 284.4
 L 365.6 232.827907 
 L 358.904 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_112">
     <path d="M 365.6 310.186047 
@@ -2667,7 +2667,7 @@ L 372.296 310.186047
 L 372.296 207.04186 
 L 365.6 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_113">
     <path d="M 372.296 310.186047 
@@ -2675,7 +2675,7 @@ L 378.992 310.186047
 L 378.992 207.04186 
 L 372.296 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_114">
     <path d="M 378.992 284.4 
@@ -2683,7 +2683,7 @@ L 385.688 284.4
 L 385.688 232.827907 
 L 378.992 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_115">
     <path d="M 385.688 284.4 
@@ -2691,7 +2691,7 @@ L 392.384 284.4
 L 392.384 232.827907 
 L 385.688 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_116">
     <path d="M 392.384 284.4 
@@ -2699,7 +2699,7 @@ L 399.08 284.4
 L 399.08 232.827907 
 L 392.384 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 67.628 283.430125 
@@ -3197,15 +3197,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -3374,7 +3374,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_examples_unstacked.svg
+++ b/docs/img/model_examples_unstacked.svg
@@ -40,7 +40,7 @@ L 70.976 213.488372
 L 70.976 213.345338 
 L 64.28 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_4">
     <path d="M 70.976 213.397692 
@@ -48,7 +48,7 @@ L 77.672 213.397692
 L 77.672 213.149951 
 L 70.976 213.149951 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_5">
     <path d="M 77.672 213.118517 
@@ -56,7 +56,7 @@ L 84.368 213.118517
 L 84.368 212.713957 
 L 77.672 212.713957 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_6">
     <path d="M 84.368 212.81651 
@@ -64,7 +64,7 @@ L 91.064 212.81651
 L 91.064 212.300795 
 L 84.368 212.300795 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 91.064 211.929029 
@@ -72,7 +72,7 @@ L 97.76 211.929029
 L 97.76 211.185804 
 L 91.064 211.185804 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 97.76 210.683647 
@@ -80,7 +80,7 @@ L 104.456 210.683647
 L 104.456 209.713544 
 L 97.76 209.713544 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 104.456 208.541675 
@@ -88,7 +88,7 @@ L 111.152 208.541675
 L 111.152 207.278435 
 L 104.456 207.278435 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 111.152 203.224984 
@@ -96,7 +96,7 @@ L 117.848 203.224984
 L 117.848 201.438493 
 L 111.152 201.438493 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 117.848 195.700608 
@@ -104,7 +104,7 @@ L 124.544 195.700608
 L 124.544 193.372187 
 L 117.848 193.372187 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 124.544 189.795421 
@@ -112,7 +112,7 @@ L 131.24 189.795421
 L 131.24 187.119504 
 L 124.544 187.119504 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 131.24 169.456713 
@@ -120,7 +120,7 @@ L 137.936 169.456713
 L 137.936 165.835387 
 L 131.24 165.835387 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 137.936 155.065234 
@@ -128,7 +128,7 @@ L 144.632 155.065234
 L 144.632 150.904943 
 L 137.936 150.904943 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 144.632 132.823629 
@@ -136,7 +136,7 @@ L 151.328 132.823629
 L 151.328 127.947877 
 L 144.632 127.947877 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 151.328 110.818212 
@@ -144,7 +144,7 @@ L 158.024 110.818212
 L 158.024 105.326759 
 L 151.328 105.326759 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 158.024 89.13495 
@@ -152,7 +152,7 @@ L 164.72 89.13495
 L 164.72 83.098654 
 L 158.024 83.098654 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 164.72 74.713674 
@@ -160,7 +160,7 @@ L 171.416 74.713674
 L 171.416 68.341042 
 L 164.72 68.341042 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 171.416 66.721704 
@@ -168,7 +168,7 @@ L 178.112 66.721704
 L 178.112 60.170196 
 L 171.416 60.170196 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 178.112 66.155809 
@@ -176,7 +176,7 @@ L 184.808 66.155809
 L 184.808 59.591821 
 L 178.112 59.591821 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 184.808 75.137956 
@@ -184,7 +184,7 @@ L 191.504 75.137956
 L 191.504 68.774963 
 L 184.808 68.774963 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 191.504 81.925451 
@@ -192,7 +192,7 @@ L 198.2 81.925451
 L 198.2 75.718709 
 L 191.504 75.718709 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 198.2 91.325591 
@@ -200,7 +200,7 @@ L 204.896 91.325591
 L 204.896 85.34206 
 L 198.2 85.34206 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 204.896 97.896081 
@@ -208,7 +208,7 @@ L 211.592 97.896081
 L 211.592 92.073711 
 L 204.896 92.073711 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 211.592 111.94754 
@@ -216,7 +216,7 @@ L 218.288 111.94754
 L 218.288 106.485972 
 L 211.592 106.485972 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 218.288 107.147347 
@@ -224,7 +224,7 @@ L 224.984 107.147347
 L 224.984 101.559868 
 L 218.288 101.559868 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 224.984 109.971164 
@@ -232,7 +232,7 @@ L 231.68 109.971164
 L 231.68 104.457402 
 L 224.984 104.457402 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 231.68 108.206335 
@@ -240,7 +240,7 @@ L 238.376 108.206335
 L 238.376 102.646386 
 L 231.68 102.646386 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 238.376 116.675689 
@@ -248,7 +248,7 @@ L 245.072 116.675689
 L 245.072 111.341085 
 L 238.376 111.341085 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 245.072 127.678308 
@@ -256,7 +256,7 @@ L 251.768 127.678308
 L 251.768 122.651734 
 L 245.072 122.651734 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 251.768 137.473498 
@@ -264,7 +264,7 @@ L 258.464 137.473498
 L 258.464 132.738237 
 L 251.768 132.738237 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 258.464 148.87726 
@@ -272,7 +272,7 @@ L 265.16 148.87726
 L 265.16 144.505946 
 L 258.464 144.505946 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 265.16 158.859664 
@@ -280,7 +280,7 @@ L 271.856 158.859664
 L 271.856 154.834337 
 L 265.16 154.834337 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 271.856 176.461178 
@@ -288,7 +288,7 @@ L 278.552 176.461178
 L 278.552 173.134298 
 L 271.856 173.134298 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 278.552 187.357634 
@@ -296,7 +296,7 @@ L 285.248 187.357634
 L 285.248 184.551109 
 L 278.552 184.551109 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 285.248 196.255036 
@@ -304,7 +304,7 @@ L 291.944 196.255036
 L 291.944 193.96203 
 L 285.248 193.96203 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 291.944 202.125403 
@@ -312,7 +312,7 @@ L 298.64 202.125403
 L 298.64 200.249533 
 L 291.944 200.249533 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 298.64 206.915935 
@@ -320,7 +320,7 @@ L 305.336 206.915935
 L 305.336 205.471365 
 L 298.64 205.471365 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 305.336 209.818208 
@@ -328,7 +328,7 @@ L 312.032 209.818208
 L 312.032 208.719544 
 L 305.336 208.719544 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 312.032 211.669538 
@@ -336,7 +336,7 @@ L 318.728 211.669538
 L 318.728 210.87316 
 L 312.032 210.87316 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 318.728 212.250445 
@@ -344,7 +344,7 @@ L 325.424 212.250445
 L 325.424 211.579557 
 L 318.728 211.579557 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 325.424 213.17697 
@@ -352,7 +352,7 @@ L 332.12 213.17697
 L 332.12 212.798538 
 L 325.424 212.798538 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 332.12 213.234451 
@@ -360,7 +360,7 @@ L 338.816 213.234451
 L 338.816 212.884091 
 L 332.12 212.884091 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 338.816 213.446478 
@@ -368,7 +368,7 @@ L 345.512 213.446478
 L 345.512 213.244198 
 L 338.816 213.244198 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 345.512 213.488372 
@@ -376,7 +376,7 @@ L 352.208 213.488372
 L 352.208 213.345338 
 L 345.512 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 352.208 213.488372 
@@ -384,7 +384,7 @@ L 358.904 213.488372
 L 358.904 213.345338 
 L 352.208 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 358.904 213.488372 
@@ -392,7 +392,7 @@ L 365.6 213.488372
 L 365.6 213.488372 
 L 358.904 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 365.6 213.488372 
@@ -400,7 +400,7 @@ L 372.296 213.488372
 L 372.296 213.345338 
 L 365.6 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 372.296 213.488372 
@@ -408,7 +408,7 @@ L 378.992 213.488372
 L 378.992 213.345338 
 L 372.296 213.345338 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 378.992 213.488372 
@@ -416,7 +416,7 @@ L 385.688 213.488372
 L 385.688 213.488372 
 L 378.992 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 385.688 213.488372 
@@ -424,7 +424,7 @@ L 392.384 213.488372
 L 392.384 213.488372 
 L 385.688 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 392.384 213.488372 
@@ -432,7 +432,7 @@ L 399.08 213.488372
 L 399.08 213.488372 
 L 392.384 213.488372 
 z
-" clip-path="url(#pf5c82a72ef)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#pf5c82a72ef)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 64.28 213.488372 
@@ -1746,12 +1746,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -1787,7 +1787,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_62">
@@ -1822,7 +1822,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -1838,7 +1838,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(302.5625 59.8575) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_64">
@@ -2007,15 +2007,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-6d" x="111.199982"/>
-      <use xlink:href="#LatinModernMath-Regular-28" x="194.499969"/>
-      <use xlink:href="#LatinModernMath-Regular-68" x="233.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="288.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="316.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="356.199936"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="395.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-29" x="434.499924"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(111.199982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-28" transform="translate(194.499969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-68" transform="translate(233.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(288.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(316.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(356.199936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(395.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-29" transform="translate(434.499924 0)"/>
      </g>
     </g>
     <g id="patch_65">
@@ -2024,7 +2024,7 @@ L 292.9625 94.5375
 L 292.9625 86.1375 
 L 268.9625 86.1375 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_11">
      <!-- Model stat. unc. -->
@@ -2167,21 +2167,21 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="302.699936"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="342.09993"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="380.999924"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="430.999908"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="469.899902"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="497.69989"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="530.899887"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="586.499878"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="642.099869"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="686.499863"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(302.699936 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(342.09993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(380.999924 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(430.999908 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(469.899902 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(497.69989 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(530.899887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(586.499878 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(642.099869 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(686.499863 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2226,9 +2226,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -2248,7 +2248,7 @@ L 70.976 310.186047
 L 70.976 207.04186 
 L 64.28 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_68">
     <path d="M 70.976 288.389115 
@@ -2256,7 +2256,7 @@ L 77.672 288.389115
 L 77.672 228.838792 
 L 70.976 228.838792 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_69">
     <path d="M 77.672 276.847442 
@@ -2264,7 +2264,7 @@ L 84.368 276.847442
 L 84.368 240.380465 
 L 77.672 240.380465 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_70">
     <path d="M 84.368 272.917479 
@@ -2272,7 +2272,7 @@ L 91.064 272.917479
 L 91.064 244.310428 
 L 84.368 244.310428 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_71">
     <path d="M 91.064 268.539007 
@@ -2280,7 +2280,7 @@ L 97.76 268.539007
 L 97.76 248.6889 
 L 91.064 248.6889 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_72">
     <path d="M 97.76 266.217844 
@@ -2288,7 +2288,7 @@ L 104.456 266.217844
 L 104.456 251.010063 
 L 97.76 251.010063 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_73">
     <path d="M 104.456 264.453343 
@@ -2296,7 +2296,7 @@ L 111.152 264.453343
 L 111.152 252.774564 
 L 104.456 252.774564 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_74">
     <path d="M 111.152 262.743026 
@@ -2304,7 +2304,7 @@ L 117.848 262.743026
 L 117.848 254.484881 
 L 111.152 254.484881 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_75">
     <path d="M 117.848 261.782002 
@@ -2312,7 +2312,7 @@ L 124.544 261.782002
 L 124.544 255.445905 
 L 117.848 255.445905 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_76">
     <path d="M 124.544 261.370598 
@@ -2320,7 +2320,7 @@ L 131.24 261.370598
 L 131.24 255.857309 
 L 124.544 255.857309 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_77">
     <path d="M 131.24 260.650929 
@@ -2328,7 +2328,7 @@ L 137.936 260.650929
 L 137.936 256.576978 
 L 131.24 256.576978 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_78">
     <path d="M 137.936 260.387039 
@@ -2336,7 +2336,7 @@ L 144.632 260.387039
 L 144.632 256.840868 
 L 137.936 256.840868 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_79">
     <path d="M 144.632 260.126859 
@@ -2344,7 +2344,7 @@ L 151.328 260.126859
 L 151.328 257.101048 
 L 144.632 257.101048 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_80">
     <path d="M 151.328 259.957232 
@@ -2352,7 +2352,7 @@ L 158.024 259.957232
 L 158.024 257.270675 
 L 151.328 257.270675 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_81">
     <path d="M 158.024 259.835986 
@@ -2360,7 +2360,7 @@ L 164.72 259.835986
 L 164.72 257.391921 
 L 158.024 257.391921 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_82">
     <path d="M 164.72 259.771489 
@@ -2368,7 +2368,7 @@ L 171.416 259.771489
 L 171.416 257.456418 
 L 164.72 257.456418 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_83">
     <path d="M 171.416 259.739885 
@@ -2376,7 +2376,7 @@ L 178.112 259.739885
 L 178.112 257.488022 
 L 171.416 257.488022 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_84">
     <path d="M 178.112 259.737745 
@@ -2384,7 +2384,7 @@ L 184.808 259.737745
 L 184.808 257.490162 
 L 178.112 257.490162 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_85">
     <path d="M 184.808 259.773243 
@@ -2392,7 +2392,7 @@ L 191.504 259.773243
 L 191.504 257.454664 
 L 184.808 257.454664 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_86">
     <path d="M 191.504 259.802427 
@@ -2400,7 +2400,7 @@ L 198.2 259.802427
 L 198.2 257.42548 
 L 191.504 257.42548 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_87">
     <path d="M 198.2 259.846762 
@@ -2408,7 +2408,7 @@ L 204.896 259.846762
 L 204.896 257.381145 
 L 198.2 257.381145 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_88">
     <path d="M 204.896 259.880886 
@@ -2416,7 +2416,7 @@ L 211.592 259.880886
 L 211.592 257.347021 
 L 204.896 257.347021 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_89">
     <path d="M 211.592 259.964582 
@@ -2424,7 +2424,7 @@ L 218.288 259.964582
 L 218.288 257.263325 
 L 211.592 257.263325 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_90">
     <path d="M 218.288 259.934147 
@@ -2432,7 +2432,7 @@ L 224.984 259.934147
 L 224.984 257.29376 
 L 218.288 257.29376 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_91">
     <path d="M 224.984 259.951797 
@@ -2440,7 +2440,7 @@ L 231.68 259.951797
 L 231.68 257.27611 
 L 224.984 257.27611 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_92">
     <path d="M 231.68 259.940683 
@@ -2448,7 +2448,7 @@ L 238.376 259.940683
 L 238.376 257.287224 
 L 231.68 257.287224 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_93">
     <path d="M 238.376 259.996727 
@@ -2456,7 +2456,7 @@ L 245.072 259.996727
 L 245.072 257.23118 
 L 238.376 257.23118 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_94">
     <path d="M 245.072 260.081464 
@@ -2464,7 +2464,7 @@ L 251.768 260.081464
 L 251.768 257.146443 
 L 245.072 257.146443 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_95">
     <path d="M 251.768 260.171746 
@@ -2472,7 +2472,7 @@ L 258.464 260.171746
 L 258.464 257.056161 
 L 251.768 257.056161 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_96">
     <path d="M 258.464 260.301444 
@@ -2480,7 +2480,7 @@ L 265.16 260.301444
 L 265.16 256.926463 
 L 258.464 256.926463 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_97">
     <path d="M 265.16 260.446488 
@@ -2488,7 +2488,7 @@ L 271.856 260.446488
 L 271.856 256.781419 
 L 265.16 256.781419 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_98">
     <path d="M 271.856 260.831211 
@@ -2496,7 +2496,7 @@ L 278.552 260.831211
 L 278.552 256.396696 
 L 271.856 256.396696 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_99">
     <path d="M 278.552 261.242311 
@@ -2504,7 +2504,7 @@ L 285.248 261.242311
 L 285.248 255.985596 
 L 278.552 255.985596 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_100">
     <path d="M 285.248 261.830932 
@@ -2512,7 +2512,7 @@ L 291.944 261.830932
 L 291.944 255.396975 
 L 285.248 255.396975 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_101">
     <path d="M 291.944 262.546289 
@@ -2520,7 +2520,7 @@ L 298.64 262.546289
 L 298.64 254.681618 
 L 291.944 254.681618 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_102">
     <path d="M 298.64 263.720352 
@@ -2528,7 +2528,7 @@ L 305.336 263.720352
 L 305.336 253.507555 
 L 298.64 253.507555 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_103">
     <path d="M 305.336 265.328068 
@@ -2536,7 +2536,7 @@ L 312.032 265.328068
 L 312.032 251.899839 
 L 305.336 251.899839 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_104">
     <path d="M 312.032 267.876575 
@@ -2544,7 +2544,7 @@ L 318.728 267.876575
 L 318.728 249.351332 
 L 312.032 249.351332 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_105">
     <path d="M 318.728 269.609161 
@@ -2552,7 +2552,7 @@ L 325.424 269.609161
 L 325.424 247.618746 
 L 318.728 247.618746 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_106">
     <path d="M 325.424 278.106372 
@@ -2560,7 +2560,7 @@ L 332.12 278.106372
 L 332.12 239.121535 
 L 325.424 239.121535 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_107">
     <path d="M 332.12 279.668172 
@@ -2568,7 +2568,7 @@ L 338.816 279.668172
 L 338.816 237.559735 
 L 332.12 237.559735 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_108">
     <path d="M 338.816 295.08093 
@@ -2576,7 +2576,7 @@ L 345.512 295.08093
 L 345.512 222.146977 
 L 338.816 222.146977 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_109">
     <path d="M 345.512 310.186047 
@@ -2584,7 +2584,7 @@ L 352.208 310.186047
 L 352.208 207.04186 
 L 345.512 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_110">
     <path d="M 352.208 310.186047 
@@ -2592,7 +2592,7 @@ L 358.904 310.186047
 L 358.904 207.04186 
 L 352.208 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_111">
     <path d="M 358.904 284.4 
@@ -2600,7 +2600,7 @@ L 365.6 284.4
 L 365.6 232.827907 
 L 358.904 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_112">
     <path d="M 365.6 310.186047 
@@ -2608,7 +2608,7 @@ L 372.296 310.186047
 L 372.296 207.04186 
 L 365.6 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_113">
     <path d="M 372.296 310.186047 
@@ -2616,7 +2616,7 @@ L 378.992 310.186047
 L 378.992 207.04186 
 L 372.296 207.04186 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_114">
     <path d="M 378.992 284.4 
@@ -2624,7 +2624,7 @@ L 385.688 284.4
 L 385.688 232.827907 
 L 378.992 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_115">
     <path d="M 385.688 284.4 
@@ -2632,7 +2632,7 @@ L 392.384 284.4
 L 392.384 232.827907 
 L 385.688 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_116">
     <path d="M 392.384 284.4 
@@ -2640,7 +2640,7 @@ L 399.08 284.4
 L 399.08 232.827907 
 L 392.384 232.827907 
 z
-" clip-path="url(#peb2c321ae7)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#peb2c321ae7)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 67.628 283.430125 
@@ -3138,15 +3138,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -3315,7 +3315,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/model_with_stacked_and_unstacked_function_components.svg
+++ b/docs/img/model_with_stacked_and_unstacked_function_components.svg
@@ -34,7 +34,7 @@ L 58.626875 20.0751
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="PolyCollection_1">
+   <g id="FillBetweenPolyCollection_1">
     <defs>
      <path id="mff08c03d89" d="M 58.626875 -54.760455 
 L 58.626875 -54.706006 
@@ -2045,7 +2045,7 @@ z
      <use xlink:href="#mff08c03d89" x="0" y="292.343225" style="fill: #e24a33; stroke: #000000; stroke-width: 0.5"/>
     </g>
    </g>
-   <g id="PolyCollection_2">
+   <g id="FillBetweenPolyCollection_2">
     <defs>
      <path id="m9d8e5da685" d="M 58.626875 -54.706006 
 L 58.626875 -50.508125 
@@ -4661,15 +4661,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -5026,18 +5026,18 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-66"/>
-      <use xlink:href="#LatinModernMath-Regular-28" x="30.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-76" x="69.499985"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="122.299973"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="172.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="211.499954"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="239.299942"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="289.299927"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="344.899918"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="372.699905"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="417.099899"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="450.399887"/>
-      <use xlink:href="#LatinModernMath-Regular-29" x="500.399872"/>
+      <use xlink:href="#LatinModernMath-Regular-28" transform="translate(30.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-76" transform="translate(69.499985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(122.299973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(172.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(211.499954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(239.299942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(289.299927 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(344.899918 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(372.699905 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(417.099899 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(450.399887 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-29" transform="translate(500.399872 0)"/>
      </g>
     </g>
    </g>
@@ -5285,28 +5285,28 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-4d"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="302.699936"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="385.999924"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="435.999908"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="491.599899"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="535.999893"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="569.19989"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="619.199875"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="649.799866"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="682.999863"/>
-     <use xlink:href="#LatinModernMath-Regular-75" x="713.599854"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="769.199844"/>
-     <use xlink:href="#LatinModernMath-Regular-63" x="824.799835"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="869.199829"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="908.099823"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="935.899811"/>
-     <use xlink:href="#LatinModernMath-Regular-6e" x="985.899796"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="1041.499786"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(302.699936 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(385.999924 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(435.999908 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(491.599899 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(535.999893 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(569.19989 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(619.199875 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(649.799866 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(682.999863 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-75" transform="translate(713.599854 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(769.199844 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-63" transform="translate(824.799835 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(869.199829 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(908.099823 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(935.899811 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(985.899796 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(1041.499786 0)"/>
     </g>
    </g>
    <g id="legend_1">
@@ -5322,7 +5322,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(350.286875 39.2751) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_8">
@@ -5337,7 +5337,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(350.286875 56.00385) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="line2d_44">
@@ -5424,11 +5424,11 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="83.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="133.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="188.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="238.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(83.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(133.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(188.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(238.999939 0)"/>
      </g>
     </g>
     <g id="line2d_45">
@@ -5441,10 +5441,10 @@ L 340.686875 85.46385
      <!-- Model -->
      <g style="fill: #1a1a1a" transform="translate(350.286875 89.66385) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/model_with_stacked_and_unstacked_histograms_components.svg
+++ b/docs/img/model_with_stacked_and_unstacked_histograms_components.svg
@@ -652,7 +652,7 @@ L 70.88225 242.10885
 L 70.88225 242.010058 
 L 64.18625 242.010058 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_7">
     <path d="M 70.88225 242.046218 
@@ -660,7 +660,7 @@ L 77.57825 242.046218
 L 77.57825 241.875105 
 L 70.88225 241.875105 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_8">
     <path d="M 77.57825 241.853394 
@@ -668,7 +668,7 @@ L 84.27425 241.853394
 L 84.27425 241.573967 
 L 77.57825 241.573967 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_9">
     <path d="M 84.27425 241.6448 
@@ -676,7 +676,7 @@ L 90.97025 241.6448
 L 90.97025 241.288599 
 L 84.27425 241.288599 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_10">
     <path d="M 90.97025 241.031823 
@@ -684,7 +684,7 @@ L 97.66625 241.031823
 L 97.66625 240.518482 
 L 90.97025 240.518482 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_11">
     <path d="M 97.66625 240.054803 
@@ -692,7 +692,7 @@ L 104.36225 240.054803
 L 104.36225 239.322185 
 L 97.66625 239.322185 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_12">
     <path d="M 104.36225 238.317664 
@@ -700,7 +700,7 @@ L 111.05825 238.317664
 L 111.05825 237.305444 
 L 104.36225 237.305444 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_13">
     <path d="M 111.05825 233.696373 
@@ -708,7 +708,7 @@ L 117.75425 233.696373
 L 117.75425 232.147096 
 L 111.05825 232.147096 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_14">
     <path d="M 117.75425 227.647603 
@@ -716,7 +716,7 @@ L 124.45025 227.647603
 L 124.45025 225.649924 
 L 117.75425 225.649924 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_15">
     <path d="M 124.45025 221.745178 
@@ -724,7 +724,7 @@ L 131.14625 221.745178
 L 131.14625 219.303594 
 L 124.45025 219.303594 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_16">
     <path d="M 131.14625 204.246313 
@@ -732,7 +732,7 @@ L 137.84225 204.246313
 L 137.84225 200.94359 
 L 131.14625 200.94359 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_17">
     <path d="M 137.84225 188.284093 
@@ -740,7 +740,7 @@ L 144.53825 188.284093
 L 144.53825 184.210379 
 L 137.84225 184.210379 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_18">
     <path d="M 144.53825 170.563789 
@@ -748,7 +748,7 @@ L 151.23425 170.563789
 L 151.23425 165.972098 
 L 144.53825 165.972098 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_19">
     <path d="M 151.23425 147.11156 
@@ -756,7 +756,7 @@ L 157.93025 147.11156
 L 157.93025 141.714184 
 L 151.23425 141.714184 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_20">
     <path d="M 157.93025 120.526257 
@@ -764,7 +764,7 @@ L 164.62625 120.526257
 L 164.62625 114.269289 
 L 157.93025 114.269289 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_21">
     <path d="M 164.62625 109.080719 
@@ -772,7 +772,7 @@ L 171.32225 109.080719
 L 171.32225 102.59856 
 L 164.62625 102.59856 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_22">
     <path d="M 171.32225 88.901727 
@@ -780,7 +780,7 @@ L 178.01825 88.901727
 L 178.01825 81.691586 
 L 171.32225 81.691586 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_23">
     <path d="M 178.01825 92.135689 
@@ -788,7 +788,7 @@ L 184.71425 92.135689
 L 184.71425 85.073825 
 L 178.01825 85.073825 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_24">
     <path d="M 184.71425 92.273098 
@@ -796,7 +796,7 @@ L 191.41025 92.273098
 L 191.41025 85.040063 
 L 184.71425 85.040063 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_25">
     <path d="M 191.41025 90.742277 
@@ -804,7 +804,7 @@ L 198.10625 90.742277
 L 198.10625 83.315704 
 L 191.41025 83.315704 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_26">
     <path d="M 198.10625 96.542281 
@@ -812,7 +812,7 @@ L 204.80225 96.542281
 L 204.80225 89.173781 
 L 198.10625 89.173781 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_27">
     <path d="M 204.80225 84.836696 
@@ -820,7 +820,7 @@ L 211.49825 84.836696
 L 211.49825 76.885756 
 L 204.80225 76.885756 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_28">
     <path d="M 211.49825 83.118176 
@@ -828,7 +828,7 @@ L 218.19425 83.118176
 L 218.19425 74.859294 
 L 211.49825 74.859294 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_29">
     <path d="M 218.19425 62.455246 
@@ -836,7 +836,7 @@ L 224.89025 62.455246
 L 224.89025 53.549206 
 L 218.19425 53.549206 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_30">
     <path d="M 224.89025 51.742661 
@@ -844,7 +844,7 @@ L 231.58625 51.742661
 L 231.58625 42.438725 
 L 224.89025 42.438725 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_31">
     <path d="M 231.58625 46.140509 
@@ -852,7 +852,7 @@ L 238.28225 46.140509
 L 238.28225 36.683218 
 L 231.58625 36.683218 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_32">
     <path d="M 238.28225 40.661557 
@@ -860,7 +860,7 @@ L 244.97825 40.661557
 L 244.97825 30.90885 
 L 238.28225 30.90885 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_33">
     <path d="M 244.97825 59.556332 
@@ -868,7 +868,7 @@ L 251.67425 59.556332
 L 251.67425 50.237836 
 L 244.97825 50.237836 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_34">
     <path d="M 251.67425 82.702583 
@@ -876,7 +876,7 @@ L 258.37025 82.702583
 L 258.37025 74.005032 
 L 251.67425 74.005032 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_35">
     <path d="M 258.37025 102.445947 
@@ -884,7 +884,7 @@ L 265.06625 102.445947
 L 265.06625 94.26323 
 L 258.37025 94.26323 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_36">
     <path d="M 265.06625 134.979762 
@@ -892,7 +892,7 @@ L 271.76225 134.979762
 L 271.76225 127.899985 
 L 265.06625 127.899985 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_37">
     <path d="M 271.76225 166.539717 
@@ -900,7 +900,7 @@ L 278.45825 166.539717
 L 278.45825 160.53972 
 L 271.76225 160.53972 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_38">
     <path d="M 278.45825 190.605874 
@@ -908,7 +908,7 @@ L 285.15425 190.605874
 L 285.15425 185.659004 
 L 278.45825 185.659004 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_39">
     <path d="M 285.15425 208.175429 
@@ -916,7 +916,7 @@ L 291.85025 208.175429
 L 291.85025 204.139547 
 L 285.15425 204.139547 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_40">
     <path d="M 291.85025 218.576627 
@@ -924,7 +924,7 @@ L 298.54625 218.576627
 L 298.54625 215.171215 
 L 291.85025 215.171215 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_41">
     <path d="M 298.54625 229.15492 
@@ -932,7 +932,7 @@ L 305.24225 229.15492
 L 305.24225 226.617734 
 L 298.54625 226.617734 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_42">
     <path d="M 305.24225 234.964859 
@@ -940,7 +940,7 @@ L 311.93825 234.964859
 L 311.93825 233.054932 
 L 305.24225 233.054932 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_43">
     <path d="M 311.93825 238.991829 
@@ -948,7 +948,7 @@ L 318.63425 238.991829
 L 318.63425 237.719382 
 L 311.93825 237.719382 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_44">
     <path d="M 318.63425 239.549033 
@@ -956,7 +956,7 @@ L 325.33025 239.549033
 L 325.33025 238.347571 
 L 318.63425 238.347571 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_45">
     <path d="M 325.33025 241.378503 
@@ -964,7 +964,7 @@ L 332.02625 241.378503
 L 332.02625 240.666342 
 L 325.33025 240.666342 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_46">
     <path d="M 332.02625 241.758131 
@@ -972,7 +972,7 @@ L 338.72225 241.758131
 L 338.72225 241.274291 
 L 332.02625 241.274291 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_47">
     <path d="M 338.72225 242.079914 
@@ -980,7 +980,7 @@ L 345.41825 242.079914
 L 345.41825 241.940201 
 L 338.72225 241.940201 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_48">
     <path d="M 345.41825 242.10885 
@@ -988,7 +988,7 @@ L 352.11425 242.10885
 L 352.11425 242.010058 
 L 345.41825 242.010058 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_49">
     <path d="M 352.11425 242.10885 
@@ -996,7 +996,7 @@ L 358.81025 242.10885
 L 358.81025 242.010058 
 L 352.11425 242.010058 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_50">
     <path d="M 358.81025 242.10885 
@@ -1004,7 +1004,7 @@ L 365.50625 242.10885
 L 365.50625 242.10885 
 L 358.81025 242.10885 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_51">
     <path d="M 365.50625 242.10885 
@@ -1012,7 +1012,7 @@ L 372.20225 242.10885
 L 372.20225 242.010058 
 L 365.50625 242.010058 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_52">
     <path d="M 372.20225 242.10885 
@@ -1020,7 +1020,7 @@ L 378.89825 242.10885
 L 378.89825 242.010058 
 L 372.20225 242.010058 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_53">
     <path d="M 378.89825 242.10885 
@@ -1028,7 +1028,7 @@ L 385.59425 242.10885
 L 385.59425 242.10885 
 L 378.89825 242.10885 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_54">
     <path d="M 385.59425 242.10885 
@@ -1036,7 +1036,7 @@ L 392.29025 242.10885
 L 392.29025 242.10885 
 L 385.59425 242.10885 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_55">
     <path d="M 392.29025 242.10885 
@@ -1044,7 +1044,7 @@ L 398.98625 242.10885
 L 398.98625 242.10885 
 L 392.29025 242.10885 
 z
-" clip-path="url(#p543c3fde6b)" style="fill: url(#h63c8cd6f62)"/>
+" clip-path="url(#p543c3fde6b)" style="fill: url(#h9863da84dd)"/>
    </g>
    <g id="patch_56">
     <path d="M 64.18625 242.10885 
@@ -1716,15 +1716,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -2157,12 +2157,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2393,29 +2393,29 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-4d"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="269.499939"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="302.699936"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="385.999924"/>
-     <use xlink:href="#LatinModernMath-Regular-64" x="435.999908"/>
-     <use xlink:href="#LatinModernMath-Regular-65" x="491.599899"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="535.999893"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="569.19989"/>
-     <use xlink:href="#LatinModernMath-Regular-66" x="619.199875"/>
-     <use xlink:href="#LatinModernMath-Regular-20" x="649.799866"/>
-     <use xlink:href="#LatinModernMath-Regular-68" x="682.999863"/>
-     <use xlink:href="#LatinModernMath-Regular-69" x="738.599854"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="766.399841"/>
-     <use xlink:href="#LatinModernMath-Regular-74" x="805.799835"/>
-     <use xlink:href="#LatinModernMath-Regular-6f" x="844.699829"/>
-     <use xlink:href="#LatinModernMath-Regular-67" x="894.699814"/>
-     <use xlink:href="#LatinModernMath-Regular-72" x="944.699799"/>
-     <use xlink:href="#LatinModernMath-Regular-61" x="983.899796"/>
-     <use xlink:href="#LatinModernMath-Regular-6d" x="1033.89978"/>
-     <use xlink:href="#LatinModernMath-Regular-73" x="1117.199768"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(269.499939 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(302.699936 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(385.999924 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-64" transform="translate(435.999908 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-65" transform="translate(491.599899 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(535.999893 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(569.19989 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-66" transform="translate(619.199875 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-20" transform="translate(649.799866 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-68" transform="translate(682.999863 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-69" transform="translate(738.599854 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(766.399841 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-74" transform="translate(805.799835 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(844.699829 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-67" transform="translate(894.699814 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-72" transform="translate(944.699799 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-61" transform="translate(983.899796 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-6d" transform="translate(1033.89978 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-73" transform="translate(1117.199768 0)"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2449,7 +2449,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_63">
@@ -2464,7 +2464,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(336.850625 56.2776) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_64">
@@ -2479,7 +2479,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(336.850625 73.00635) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_65">
@@ -2528,11 +2528,11 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="83.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="133.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="188.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="238.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(83.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(133.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(188.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(238.999939 0)"/>
      </g>
     </g>
     <g id="patch_66">
@@ -2548,10 +2548,10 @@ z
      <!-- Model -->
      <g style="fill: #1a1a1a" transform="translate(336.850625 106.66635) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
      </g>
     </g>
     <g id="patch_67">
@@ -2560,7 +2560,7 @@ L 327.250625 123.3951
 L 327.250625 114.9951 
 L 303.250625 114.9951 
 z
-" style="fill: url(#h63c8cd6f62)"/>
+" style="fill: url(#h9863da84dd)"/>
     </g>
     <g id="text_19">
      <!-- Stat. unc. -->
@@ -2596,15 +2596,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="94.499985"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="144.499969"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="183.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-20" x="211.199951"/>
-      <use xlink:href="#LatinModernMath-Regular-75" x="244.399948"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="299.999939"/>
-      <use xlink:href="#LatinModernMath-Regular-63" x="355.59993"/>
-      <use xlink:href="#LatinModernMath-Regular-2e" x="399.999924"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(94.499985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(144.499969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(183.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-20" transform="translate(211.199951 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-75" transform="translate(244.399948 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(299.999939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-63" transform="translate(355.59993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-2e" transform="translate(399.999924 0)"/>
      </g>
     </g>
    </g>
@@ -2616,7 +2616,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h63c8cd6f62" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9863da84dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="none"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/img/plothist_example.svg
+++ b/docs/img/plothist_example.svg
@@ -908,12 +908,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
     <g id="text_9">
@@ -1019,7 +1019,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-68"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="55.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(55.599991 0)"/>
      </g>
     </g>
     <g id="patch_10">
@@ -1035,7 +1035,7 @@ z
      <!-- h2 -->
      <g style="fill: #1a1a1a" transform="translate(372.215 56.539687) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-68"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="55.599991"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(55.599991 0)"/>
      </g>
     </g>
    </g>
@@ -1429,13 +1429,13 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-56"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="74.999985"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="124.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="164.199966"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="191.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="241.999939"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="297.59993"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="325.399918"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(74.999985 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(124.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(164.199966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(191.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(241.999939 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(297.59993 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(325.399918 0)"/>
      </g>
     </g>
    </g>
@@ -1549,10 +1549,10 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-52"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="73.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="162.499969"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="190.299957"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(73.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(162.499969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(190.299957 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/ratio_data_vs_model_with_stacked_and_unstacked_function_components.svg
+++ b/docs/img/ratio_data_vs_model_with_stacked_and_unstacked_function_components.svg
@@ -34,7 +34,7 @@ L 62.48 7.2
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="PolyCollection_1">
+   <g id="FillBetweenPolyCollection_1">
     <defs>
      <path id="mccf2dc9323" d="M 62.48 -125.161073 
 L 62.48 -125.113167 
@@ -2045,7 +2045,7 @@ z
      <use xlink:href="#mccf2dc9323" x="0" y="334.908125" style="fill: #e24a33; stroke: #000000; stroke-width: 0.5"/>
     </g>
    </g>
-   <g id="PolyCollection_2">
+   <g id="FillBetweenPolyCollection_2">
     <defs>
      <path id="mbd78aca473" d="M 62.48 -125.113167 
 L 62.48 -121.419753 
@@ -5088,12 +5088,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -5145,7 +5145,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_8">
@@ -5160,7 +5160,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(354.14 43.12875) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="line2d_46">
@@ -5291,11 +5291,11 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-53"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="55.599991"/>
-      <use xlink:href="#LatinModernMath-Regular-67" x="83.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="133.399963"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="188.999954"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="238.999939"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(55.599991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-67" transform="translate(83.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(133.399963 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(188.999954 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(238.999939 0)"/>
      </g>
     </g>
     <g id="line2d_47">
@@ -5393,10 +5393,10 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-4d"/>
-      <use xlink:href="#LatinModernMath-Regular-6f" x="91.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-64" x="141.699966"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="197.299957"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="241.699951"/>
+      <use xlink:href="#LatinModernMath-Regular-6f" transform="translate(91.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-64" transform="translate(141.699966 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(197.299957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(241.699951 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -5441,9 +5441,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -5968,15 +5968,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/usage_colorpalette_examples.svg
+++ b/docs/img/usage_colorpalette_examples.svg
@@ -1916,15 +1916,15 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -2318,12 +2318,12 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -2714,7 +2714,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-35" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-35" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_14">
@@ -2729,7 +2729,7 @@ z
      <!-- c4 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 56.51275) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-34" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-34" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_15">
@@ -2772,7 +2772,7 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-33" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_16">
@@ -2787,7 +2787,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 89.97025) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_17">
@@ -2802,7 +2802,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 106.699) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_18">
@@ -2817,7 +2817,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 123.42775) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_2">
@@ -2862,9 +2862,9 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -4492,15 +4492,15 @@ L 726.28625 20.584
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(535.324276 306.799) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -4666,12 +4666,12 @@ L 726.28625 20.584
      <!-- Entries -->
      <g style="fill: #1a1a1a" transform="translate(384.929489 171.990563) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -4850,7 +4850,7 @@ z
      <!-- c5 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 39.784) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-35" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-35" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_31">
@@ -4865,7 +4865,7 @@ z
      <!-- c4 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 56.51275) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-34" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-34" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_32">
@@ -4880,7 +4880,7 @@ z
      <!-- c3 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 73.2415) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-33" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_33">
@@ -4895,7 +4895,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 89.97025) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_34">
@@ -4910,7 +4910,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 106.699) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_35">
@@ -4925,7 +4925,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 123.42775) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_4">
@@ -4943,9 +4943,9 @@ L 668.04875 129.9565
      <!-- Data -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 140.1565) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -6573,15 +6573,15 @@ L 361.049886 328.584
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(170.087912 614.799) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -6747,12 +6747,12 @@ L 361.049886 328.584
      <!-- Entries -->
      <g style="fill: #1a1a1a" transform="translate(19.693125 479.990562) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -6823,7 +6823,7 @@ z
      <!-- c5 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 347.784) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-35" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-35" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_48">
@@ -6838,7 +6838,7 @@ z
      <!-- c4 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 364.51275) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-34" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-34" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_49">
@@ -6853,7 +6853,7 @@ z
      <!-- c3 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 381.2415) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-33" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_50">
@@ -6868,7 +6868,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 397.97025) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_51">
@@ -6883,7 +6883,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 414.699) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_52">
@@ -6898,7 +6898,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 431.42775) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_6">
@@ -6916,9 +6916,9 @@ L 302.812386 437.9565
      <!-- Data -->
      <g style="fill: #1a1a1a" transform="translate(324.412386 448.1565) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>
@@ -8546,15 +8546,15 @@ L 726.28625 328.584
      <!-- variable_1 -->
      <g style="fill: #1a1a1a" transform="translate(535.324276 614.799) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-76"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="52.799988"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="102.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="141.999969"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="169.799957"/>
-      <use xlink:href="#LatinModernMath-Regular-62" x="219.799942"/>
-      <use xlink:href="#LatinModernMath-Regular-6c" x="275.399933"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="303.199921"/>
-      <use xlink:href="#LatinModernMath-Regular-5f" x="347.599915"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="380.899902"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(52.799988 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(102.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(141.999969 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(169.799957 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-62" transform="translate(219.799942 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-6c" transform="translate(275.399933 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(303.199921 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-5f" transform="translate(347.599915 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(380.899902 0)"/>
      </g>
     </g>
    </g>
@@ -8720,12 +8720,12 @@ L 726.28625 328.584
      <!-- Entries -->
      <g style="fill: #1a1a1a" transform="translate(384.929489 479.990562) rotate(-90) scale(0.18 -0.18)">
       <use xlink:href="#LatinModernMath-Regular-45"/>
-      <use xlink:href="#LatinModernMath-Regular-6e" x="68.099991"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="123.699982"/>
-      <use xlink:href="#LatinModernMath-Regular-72" x="162.599976"/>
-      <use xlink:href="#LatinModernMath-Regular-69" x="201.799973"/>
-      <use xlink:href="#LatinModernMath-Regular-65" x="229.59996"/>
-      <use xlink:href="#LatinModernMath-Regular-73" x="273.999954"/>
+      <use xlink:href="#LatinModernMath-Regular-6e" transform="translate(68.099991 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(123.699982 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-72" transform="translate(162.599976 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-69" transform="translate(201.799973 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-65" transform="translate(229.59996 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-73" transform="translate(273.999954 0)"/>
      </g>
     </g>
    </g>
@@ -8952,7 +8952,7 @@ z
      <!-- c5 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 347.784) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-35" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-35" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_65">
@@ -8967,7 +8967,7 @@ z
      <!-- c4 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 364.51275) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-34" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-34" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_66">
@@ -8982,7 +8982,7 @@ z
      <!-- c3 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 381.2415) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-33" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-33" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_67">
@@ -8997,7 +8997,7 @@ z
      <!-- c2 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 397.97025) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-32" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-32" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_68">
@@ -9012,7 +9012,7 @@ z
      <!-- c1 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 414.699) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-31" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-31" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="patch_69">
@@ -9027,7 +9027,7 @@ z
      <!-- c0 -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 431.42775) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-63"/>
-      <use xlink:href="#LatinModernMath-Regular-30" x="44.399994"/>
+      <use xlink:href="#LatinModernMath-Regular-30" transform="translate(44.399994 0)"/>
      </g>
     </g>
     <g id="LineCollection_8">
@@ -9045,9 +9045,9 @@ L 668.04875 437.9565
      <!-- Data -->
      <g style="fill: #1a1a1a" transform="translate(689.64875 448.1565) scale(0.12 -0.12)">
       <use xlink:href="#LatinModernMath-Regular-44"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="76.399994"/>
-      <use xlink:href="#LatinModernMath-Regular-74" x="126.399979"/>
-      <use xlink:href="#LatinModernMath-Regular-61" x="165.299973"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(76.399994 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-74" transform="translate(126.399979 0)"/>
+      <use xlink:href="#LatinModernMath-Regular-61" transform="translate(165.299973 0)"/>
      </g>
     </g>
    </g>

--- a/docs/img/usage_style_cycle.svg
+++ b/docs/img/usage_style_cycle.svg
@@ -304,12 +304,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-33" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-34" x="133.299973"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="183.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-41" x="233.299942"/>
-     <use xlink:href="#LatinModernMath-Regular-42" x="308.299927"/>
-     <use xlink:href="#LatinModernMath-Regular-44" x="379.099915"/>
+     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-34" transform="translate(133.299973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(183.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-41" transform="translate(233.299942 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-42" transform="translate(308.299927 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-44" transform="translate(379.099915 0)"/>
     </g>
    </g>
    <g id="text_2">
@@ -371,12 +371,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-45" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-32" x="151.399979"/>
-     <use xlink:href="#LatinModernMath-Regular-34" x="201.399963"/>
-     <use xlink:href="#LatinModernMath-Regular-41" x="251.399948"/>
-     <use xlink:href="#LatinModernMath-Regular-33" x="326.399933"/>
-     <use xlink:href="#LatinModernMath-Regular-33" x="376.399918"/>
+     <use xlink:href="#LatinModernMath-Regular-45" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(151.399979 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-34" transform="translate(201.399963 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-41" transform="translate(251.399948 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(326.399933 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-33" transform="translate(376.399918 0)"/>
     </g>
    </g>
    <g id="text_3">
@@ -439,12 +439,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-39" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="133.299973"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="183.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-45" x="233.299942"/>
-     <use xlink:href="#LatinModernMath-Regular-44" x="301.399933"/>
-     <use xlink:href="#LatinModernMath-Regular-35" x="377.799927"/>
+     <use xlink:href="#LatinModernMath-Regular-39" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(133.299973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(183.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-45" transform="translate(233.299942 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-44" transform="translate(301.399933 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-35" transform="translate(377.799927 0)"/>
     </g>
    </g>
    <g id="text_4">
@@ -473,12 +473,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="133.299973"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="183.299957"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="233.299942"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="283.299927"/>
-     <use xlink:href="#LatinModernMath-Regular-37" x="333.299911"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(133.299973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(183.299957 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(233.299942 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(283.299927 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-37" transform="translate(333.299911 0)"/>
     </g>
    </g>
    <g id="text_5">
@@ -553,36 +553,36 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-46" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-42" x="148.599976"/>
-     <use xlink:href="#LatinModernMath-Regular-43" x="219.399963"/>
-     <use xlink:href="#LatinModernMath-Regular-31" x="291.599945"/>
-     <use xlink:href="#LatinModernMath-Regular-35" x="341.59993"/>
-     <use xlink:href="#LatinModernMath-Regular-45" x="391.599915"/>
+     <use xlink:href="#LatinModernMath-Regular-46" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-42" transform="translate(148.599976 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-43" transform="translate(219.399963 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-31" transform="translate(291.599945 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-35" transform="translate(341.59993 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-45" transform="translate(391.599915 0)"/>
     </g>
    </g>
    <g id="text_6">
     <!-- #8EBA42 -->
     <g style="fill: #1a1a1a" transform="translate(348.407476 72.6192) scale(0.1 -0.1)">
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-45" x="133.299973"/>
-     <use xlink:href="#LatinModernMath-Regular-42" x="201.399963"/>
-     <use xlink:href="#LatinModernMath-Regular-41" x="272.199951"/>
-     <use xlink:href="#LatinModernMath-Regular-34" x="347.199936"/>
-     <use xlink:href="#LatinModernMath-Regular-32" x="397.199921"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-45" transform="translate(133.299973 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-42" transform="translate(201.399963 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-41" transform="translate(272.199951 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-34" transform="translate(347.199936 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-32" transform="translate(397.199921 0)"/>
     </g>
    </g>
    <g id="text_7">
     <!-- #FFB5B8 -->
     <g style="fill: #1a1a1a" transform="translate(409.592632 72.6192) scale(0.1 -0.1)">
      <use xlink:href="#LatinModernMath-Regular-23"/>
-     <use xlink:href="#LatinModernMath-Regular-46" x="83.299988"/>
-     <use xlink:href="#LatinModernMath-Regular-46" x="148.599976"/>
-     <use xlink:href="#LatinModernMath-Regular-42" x="213.899963"/>
-     <use xlink:href="#LatinModernMath-Regular-35" x="284.699951"/>
-     <use xlink:href="#LatinModernMath-Regular-42" x="334.699936"/>
-     <use xlink:href="#LatinModernMath-Regular-38" x="405.499924"/>
+     <use xlink:href="#LatinModernMath-Regular-46" transform="translate(83.299988 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-46" transform="translate(148.599976 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-42" transform="translate(213.899963 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-35" transform="translate(284.699951 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-42" transform="translate(334.699936 0)"/>
+     <use xlink:href="#LatinModernMath-Regular-38" transform="translate(405.499924 0)"/>
     </g>
    </g>
   </g>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version", "description"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "boost-histogram>=1.4.0",
     "numpy>=1.14.5",

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -40,7 +40,9 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
 
     import matplotlib
 
-    if matplotlib.__version__ < _matplotlib_version:
+    if tuple(map(int, matplotlib.__version__.split("."))) < tuple(
+        map(int, _matplotlib_version.split("."))
+    ):
         warnings.warn(
             f"svg behavior is not consistent across matplotlib versions. Please run this script with matplotlib {_matplotlib_version} or higher. Skipping.",
             stacklevel=2,
@@ -49,7 +51,9 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
 
     import numpy
 
-    if numpy.__version__ < _numpy_version:
+    if tuple(map(int, numpy.__version__.split("."))) < tuple(
+        map(int, _numpy_version.split("."))
+    ):
         warnings.warn(
             f"svg behavior is not consistent across numpy versions. Please run this script with numpy {_numpy_version} or higher. Skipping.",
             stacklevel=2,

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -30,14 +30,6 @@ def make_examples(no_input=False, check_svg=False, print_code=False):
         If the example or img folder does not exist, the function will raise a FileNotFoundError.
     """
 
-    # If python version is lower than 3.9, return a warning
-    if sys.version_info < (3, 9):
-        warnings.warn(
-            "svg behavior is not consistent across python versions. Please run this script with python 3.9 or higher. Skipping.",
-            stacklevel=2,
-        )
-        return 1
-
     import matplotlib
 
     if tuple(map(int, matplotlib.__version__.split("."))) < tuple(

--- a/src/plothist/scripts/make_examples.py
+++ b/src/plothist/scripts/make_examples.py
@@ -7,7 +7,7 @@ import warnings
 import sys
 
 
-_matplotlib_version = "3.9.0"
+_matplotlib_version = "3.10.0"
 _numpy_version = "2.0.0"
 
 

--- a/src/plothist/variable_registry.py
+++ b/src/plothist/variable_registry.py
@@ -178,7 +178,7 @@ def update_variable_registry(
     path : str, optional
         The path to the variable registry file (default is "./variable_registry.yaml").
     overwrite : bool, optional
-        If True, the keys will be overwrite by the provided value in the dictonnary (default is False).
+        If True, the keys will be overwrite by the provided value in the dictionary (default is False).
 
     Returns
     -------


### PR DESCRIPTION
* Fix version comparison when making examples
* Update pre-commit hooks
* Run pre-commit actions
* Update figures to matplotlib 3.10.0
* Require python>=3.9, test up to python3.13