### PR TITLE
feat: add copy button to doc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
         exclude: '.*\.svg$'
       - id: name-tests-test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
 docs = [
     "sphinx_gallery",
     "sphinx_rtd_theme",
+    "sphinx-copybutton",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1213,7 +1213,6 @@ wheels = [
 
 [[package]]
 name = "plothist"
-version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "boost-histogram" },
@@ -1232,6 +1231,7 @@ dev = [
     { name = "pre-commit" },
 ]
 docs = [
+    { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-rtd-theme" },
 ]
@@ -1253,6 +1253,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [{ name = "pre-commit", specifier = ">=4.1.0" }]
 docs = [
+    { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-rtd-theme" },
 ]
@@ -1631,6 +1632,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741 },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a nice copy button to all the code blocks of the doc.
Also removed unnecessary precommit check on requirements.txt.