### PR TITLE
docs: remove type hinting from API documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+# Remove type hints from function signatures, but include them in the docstring
+autodoc_typehints = "description"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Remove type hinting from API documentation