### PR TITLE
chore: codecov.yml does not need to ignore scripts anymore, because make_examples.py was removed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
 comment: false
 
 github_checks: false
-
-ignore:
-  - "src/plothist/scripts"


### PR DESCRIPTION
chore: `codecov.yml` does not need to ignore scripts anymore, because `make_examples.py` was removed