### PR TITLE
style: ignore less errors from the linter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,8 @@
 import sys
 
+from sphinx_gallery.scrapers import matplotlib_scraper
+from sphinx_gallery.sorting import ExplicitOrder
+
 import plothist
 
 #
@@ -175,9 +178,6 @@ def reset_mpl(gallery_conf, fname):
     set_style("default")
 
 
-from sphinx_gallery.scrapers import matplotlib_scraper
-
-
 class matplotlib_svg_scraper:
     def __repr__(self):
         return self.__class__.__name__
@@ -185,8 +185,6 @@ class matplotlib_svg_scraper:
     def __call__(self, *args, **kwargs):
         return matplotlib_scraper(*args, format="svg", bbox_inches="tight", **kwargs)
 
-
-from sphinx_gallery.sorting import ExplicitOrder
 
 sphinx_gallery_conf = {
     # path to your example scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,10 @@ extend-select = [
     "PD",          # pandas-vet
 ]
 ignore = [
-    "E402",  # module level import not at top of file
     "NPY002",  # Replace legacy `np.random` call with `np.random.Generator`
+]
+[tool.ruff.lint.per-file-ignores]
+"src/plothist/examples/**/*.py" = [
+    "E402",  # module level import not at top of file
     "PD901",  # Avoid using the generic variable name `df` for DataFrames
 ]

--- a/src/plothist/__init__.py
+++ b/src/plothist/__init__.py
@@ -85,18 +85,19 @@ __all__ = [
 ]
 
 
-# Get style file and use it
+from importlib import resources
 from importlib.resources import files
 
+import boost_histogram as bh
+import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt
+
+# Get style file and use it
 
 style_file = files("plothist").joinpath("default_style.mplstyle")
 plt.style.use(style_file)
 
 # Install fonts
-from importlib import resources
-
-import matplotlib.font_manager as fm
 
 with resources.as_file(resources.files("plothist_utils") / "fonts") as font_path:
     font_files = fm.findSystemFonts(fontpaths=[str(font_path)])
@@ -104,7 +105,6 @@ with resources.as_file(resources.files("plothist_utils") / "fonts") as font_path
         fm.fontManager.addfont(font)
 
 # Check version of boost_histogram
-import boost_histogram as bh
 
 if tuple(int(part) for part in bh.__version__.split(".")) < (1, 4, 0):
     raise ImportError(

--- a/tests/test_variable_registry.py
+++ b/tests/test_variable_registry.py
@@ -99,7 +99,7 @@ def test_update_variable_registry_ranges() -> None:
     """
     Test variable registry range update.
     """
-    df = get_dummy_data()
+    dummy_data = get_dummy_data()
 
     registry_path = "./_test_variable_registry_ranges.yaml"
 
@@ -109,7 +109,7 @@ def test_update_variable_registry_ranges() -> None:
     )
 
     with pytest.raises(RuntimeError) as err:
-        update_variable_registry_ranges(df, variable_keys, path=registry_path)
+        update_variable_registry_ranges(dummy_data, variable_keys, path=registry_path)
     assert (
         str(err.value)
         == f"Variable {variable_keys[0]} does not have a name, bins or range property in the registry {registry_path}."
@@ -123,7 +123,7 @@ def test_update_variable_registry_ranges() -> None:
     )
 
     with pytest.raises(RuntimeError) as err:
-        update_variable_registry_ranges(df, variable_keys, path=registry_path)
+        update_variable_registry_ranges(dummy_data, variable_keys, path=registry_path)
     assert (
         str(err.value)
         == f"Variable {variable_keys[0]} does not have a name, bins or range property in the registry {registry_path}."
@@ -137,7 +137,7 @@ def test_update_variable_registry_ranges() -> None:
     )
 
     with pytest.raises(RuntimeError) as err:
-        update_variable_registry_ranges(df, variable_keys, path=registry_path)
+        update_variable_registry_ranges(dummy_data, variable_keys, path=registry_path)
     assert (
         str(err.value)
         == f"Variable {variable_keys[0]} does not have a name, bins or range property in the registry {registry_path}."
@@ -151,7 +151,7 @@ def test_update_variable_registry_ranges() -> None:
     )
 
     with pytest.raises(RuntimeError) as err:
-        update_variable_registry_ranges(df, variable_keys, path=registry_path)
+        update_variable_registry_ranges(dummy_data, variable_keys, path=registry_path)
     assert (
         str(err.value)
         == f"Variable {variable_keys[0]} does not have a name, bins or range property in the registry {registry_path}."
@@ -160,7 +160,7 @@ def test_update_variable_registry_ranges() -> None:
     # Standard registry creation
     create_variable_registry(variable_keys, path=registry_path, reset=True)
 
-    update_variable_registry_ranges(df, variable_keys, path=registry_path)
+    update_variable_registry_ranges(dummy_data, variable_keys, path=registry_path)
 
     for key in variable_keys:
         registry = get_variable_from_registry(key, path=registry_path)
@@ -183,14 +183,14 @@ def test_update_variable_registry_ranges() -> None:
     assert registry["range"] == (-1, 1)
 
     # Range values shouldn't be updated as overwrite=False
-    update_variable_registry_ranges(df, ["variable_0"], path=registry_path)
+    update_variable_registry_ranges(dummy_data, ["variable_0"], path=registry_path)
 
     registry = get_variable_from_registry("variable_0", path=registry_path)
     assert registry["range"] == (-1, 1)
 
     # Range values should be updated as overwrite=True
     update_variable_registry_ranges(
-        df, ["variable_0"], path=registry_path, overwrite=True
+        dummy_data, ["variable_0"], path=registry_path, overwrite=True
     )
 
     registry = get_variable_from_registry("variable_0", path=registry_path)
@@ -316,16 +316,16 @@ def test_update_variable_registry_ranges_all_keys() -> None:
     """
     Test update of variable registry with variable_keys=None
     """
-    df = get_dummy_data()
+    dummy_data = get_dummy_data()
 
     registry_path = "./_test_variable_registry_update_all_keys.yaml"
 
     create_variable_registry(variable_keys, path=registry_path)
-    update_variable_registry_ranges(df, variable_keys=None, path=registry_path)
+    update_variable_registry_ranges(dummy_data, variable_keys=None, path=registry_path)
 
     for key in variable_keys:
         variable = get_variable_from_registry(key, path=registry_path)
-        assert pytest.approx(variable["range"][0]) == df[key].min()
-        assert pytest.approx(variable["range"][1]) == df[key].max()
+        assert pytest.approx(variable["range"][0]) == dummy_data[key].min()
+        assert pytest.approx(variable["range"][1]) == dummy_data[key].max()
 
     os.remove(registry_path)


### PR DESCRIPTION
Ignore less errors from the linter.

Allow certain exceptions only in the examples.