### PR TITLE
docs: add a CONTRIBUTING.md at the root of the repository and make the author list nicer in the markdown rendering

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,2 +1,2 @@
-Cyrille Praz ([@cyrraz](https://github.com/cyrraz))
-Tristan Fillinger ([@0ctagon](https://github.com/0ctagon))
+* Cyrille Praz ([@cyrraz](https://github.com/cyrraz))
+* Tristan Fillinger ([@0ctagon](https://github.com/0ctagon))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+For contributing, refer to the chapter [Contributing](https://plothist.readthedocs.io/en/latest/CONTRIBUTING.html) in the documentation.


### PR DESCRIPTION
docs: add a CONTRIBUTING.md at the root of the repository and make the author list nicer in the markdown rendering