### PR TITLE
fix: prevent input mutation and figure leaks in plotters

### DIFF
--- a/src/plothist/plotters.py
+++ b/src/plothist/plotters.py
@@ -53,11 +53,14 @@ def create_comparison_figure(
         Array of Axes objects representing the subplots.
     """
     if gridspec_kw is None:
-        gridspec_kw = {"height_ratios": [4, 1]}
+        gridspec_kw = {"height_ratios": [4] + [1] * (nrows - 1)}
     if figsize is None:
         figsize = plt.rcParams["figure.figsize"]
 
-    fig, axes = plt.subplots(nrows=nrows, figsize=figsize, gridspec_kw=gridspec_kw)
+    fig, axes = plt.subplots(
+        nrows=nrows, figsize=figsize, gridspec_kw=gridspec_kw, squeeze=False
+    )
+    axes = axes.ravel()
     if nrows > 1:
         fig.subplots_adjust(hspace=hspace)
 
@@ -87,7 +90,7 @@ def plot_hist(hist: bh.Histogram | list[bh.Histogram], ax: plt.Axes, **kwargs) -
         ax.hist(
             x=hist.axes[0].centers,
             bins=hist.axes[0].edges,
-            weights=np.nan_to_num(hist.values(), 0),
+            weights=np.nan_to_num(hist.values(), nan=0),
             **kwargs,
         )
     else:
@@ -96,7 +99,7 @@ def plot_hist(hist: bh.Histogram | list[bh.Histogram], ax: plt.Axes, **kwargs) -
         ax.hist(
             x=[h.axes[0].centers for h in hist],
             bins=hist[0].axes[0].edges,
-            weights=[np.nan_to_num(h.values(), 0) for h in hist],
+            weights=[np.nan_to_num(h.values(), nan=0) for h in hist],
             **kwargs,
         )
 
@@ -217,7 +220,7 @@ def plot_function(
         else:
             ax.plot(
                 x,
-                np.array([func(x) for func in func]).T,
+                np.array([f(x) for f in func]).T,
                 **kwargs,
             )
     else:
@@ -878,7 +881,7 @@ def plot_model(
 
     # Create copies of the kwargs arguments passed as lists/dicts to avoid modifying them
     stacked_kwargs = stacked_kwargs.copy()
-    unstacked_kwargs_list = unstacked_kwargs_list.copy()
+    unstacked_kwargs_list = [dict(kwargs) for kwargs in unstacked_kwargs_list]
     model_sum_kwargs = model_sum_kwargs.copy()
 
     components = stacked_components + unstacked_components
@@ -943,7 +946,7 @@ def plot_model(
         if unstacked_labels is None:
             unstacked_labels = [None] * len(unstacked_components)
         if len(unstacked_kwargs_list) == 0:
-            unstacked_kwargs_list = [{}] * len(unstacked_components)
+            unstacked_kwargs_list = [{} for _ in unstacked_components]
         for component, color, label, unstacked_kwargs in zip(
             unstacked_components,
             unstacked_colors,
@@ -976,15 +979,16 @@ def plot_model(
             len(unstacked_components) > 1 or len(stacked_components) > 0
         ):
             if model_type == "histograms":
+                components_sum = sum(components)
                 plot_hist(
-                    sum(components),
+                    components_sum,
                     ax=ax,
                     histtype="step",
                     **model_sum_kwargs,
                 )
                 if model_uncertainty:
                     plot_hist_uncertainties(
-                        sum(components), ax=ax, label=model_uncertainty_label
+                        components_sum, ax=ax, label=model_uncertainty_label
                     )
             else:
 
@@ -1118,7 +1122,7 @@ def plot_data_model_comparison(
 
     # Create copies of the kwargs arguments passed as lists/dicts to avoid modifying them
     stacked_kwargs = stacked_kwargs.copy()
-    unstacked_kwargs_list = unstacked_kwargs_list.copy()
+    unstacked_kwargs_list = [dict(kwargs) for kwargs in unstacked_kwargs_list]
     model_sum_kwargs = model_sum_kwargs.copy()
 
     comparison_kwargs.setdefault("h1_label", data_label)
@@ -1141,10 +1145,12 @@ def plot_data_model_comparison(
         if plot_only is None:
             fig, (ax_main, ax_comparison) = create_comparison_figure()
         elif plot_only == "ax_main":
-            _, ax_comparison = plt.subplots()
+            dummy_fig, ax_comparison = plt.subplots()
+            plt.close(dummy_fig)
             fig, ax_main = plt.subplots()
         elif plot_only == "ax_comparison":
-            _, ax_main = plt.subplots()
+            dummy_fig, ax_main = plt.subplots()
+            plt.close(dummy_fig)
             fig, ax_comparison = plt.subplots()
         else:
             raise ValueError("plot_only must be 'ax_main', 'ax_comparison' or None.")

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -289,3 +289,71 @@ def test_plot_data_model_comparison_cases() -> None:
         plot_data_model_comparison(
             data_hist=h_1d, stacked_components=[func], plot_only="invalid"
         )
+
+
+def test_plot_hist_does_not_mutate_nan_histogram() -> None:
+    """
+    Test that plot_hist does not modify the input histogram's storage when it
+    contains NaN bin values (the NaN-to-zero replacement must operate on a copy).
+    """
+    from plothist import plot_hist
+
+    h_1d = make_hist(data=[1, 2, 3], bins=3, range=(0, 3))
+    h_1d.values()[1] = np.nan
+
+    fig, ax = plt.subplots()
+    plot_hist(h_1d, ax=ax)
+    plt.close(fig)
+
+    assert np.isnan(h_1d.values()[1])
+
+
+def test_plot_model_does_not_mutate_unstacked_kwargs_list() -> None:
+    """
+    Test that plot_model does not modify a user-provided unstacked_kwargs_list
+    (or the dicts it contains).
+    """
+    h_1d = make_hist(data=[1, 2, 3], bins=3, range=(0, 3))
+
+    unstacked_kwargs_list = [{}]
+    fig, ax = plt.subplots()
+    plot_model(
+        unstacked_components=[h_1d],
+        unstacked_kwargs_list=unstacked_kwargs_list,
+        fig=fig,
+        ax=ax,
+    )
+    plt.close(fig)
+
+    assert unstacked_kwargs_list == [{}]
+
+
+def test_create_comparison_figure_nrows_one() -> None:
+    """
+    Test that create_comparison_figure(nrows=1) returns a figure and a 1-element
+    axes array (and does not crash on the ticklabel loop).
+    """
+    fig, axes = create_comparison_figure(nrows=1)
+    assert isinstance(axes, np.ndarray)
+    assert len(axes) == 1
+    plt.close(fig)
+
+
+def test_plot_data_model_comparison_does_not_leak_figures() -> None:
+    """
+    Test that plot_data_model_comparison with plot_only does not leak the
+    throwaway dummy figure (open figure count increases by at most 1).
+    """
+    h_1d = make_hist(data=[1, 2, 3], bins=3, range=(0, 3))
+
+    n_figures_before = len(plt.get_fignums())
+    fig, _, _ = plot_data_model_comparison(
+        data_hist=h_1d,
+        stacked_components=[h_1d],
+        stacked_labels=["model"],
+        plot_only="ax_main",
+    )
+    n_figures_after = len(plt.get_fignums())
+    plt.close(fig)
+
+    assert n_figures_after - n_figures_before <= 1

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -13,6 +13,7 @@ from plothist import (
     plot_2d_hist_with_projections,
     plot_data_model_comparison,
     plot_function,
+    plot_hist,
     plot_model,
     plot_two_hist_comparison,
     savefig,
@@ -296,7 +297,6 @@ def test_plot_hist_does_not_mutate_nan_histogram() -> None:
     Test that plot_hist does not modify the input histogram's storage when it
     contains NaN bin values (the NaN-to-zero replacement must operate on a copy).
     """
-    from plothist import plot_hist
 
     h_1d = make_hist(data=[1, 2, 3], bins=3, range=(0, 3))
     h_1d.values()[1] = np.nan


### PR DESCRIPTION
:robot: Claude Opus

- plot_hist: fix np.nan_to_num(values, 0) passing 0 as copy arg (in-place mutation)
- plot_model / plot_data_model_comparison: deep-copy unstacked_kwargs_list dicts
- plot_model: use list comprehension instead of [{}]*n
- plot_model: compute sum(components) once
- plot_data_model_comparison: close dummy figure in plot_only path
- create_comparison_figure: squeeze=False+ravel(), default height_ratios from nrows
- plot_function: rename shadowed loop variable func -> f