### PR TITLE
fix: make variable registry robust to empty files and shared custom dicts

### DIFF
--- a/src/plothist/variable_registry.py
+++ b/src/plothist/variable_registry.py
@@ -4,6 +4,7 @@ Collection of functions to manage the variable registry
 
 from __future__ import annotations
 
+import copy
 import os
 import warnings
 from typing import Any
@@ -61,6 +62,28 @@ def _save_variable_registry(
             f.write("\n" * 2)
 
 
+def _load_variable_registry(path: str) -> dict[str, Any]:
+    """
+    Load the variable registry from a yaml file.
+
+    Returns an empty dict if the file is empty (yaml.safe_load returns None for
+    an empty file).
+
+    Parameters
+    ----------
+    path : str
+        The path to the variable registry file.
+
+    Returns
+    -------
+    dict[str, Any]
+        The variable registry, or {} if the file is empty.
+    """
+    with open(path) as f:
+        variable_registry = yaml.safe_load(f)
+    return variable_registry if variable_registry is not None else {}
+
+
 def create_variable_registry(
     variable_keys: list[str],
     path: str = "./variable_registry.yaml",
@@ -111,33 +134,25 @@ def create_variable_registry(
     """
 
     if not os.path.exists(path):
-        with open(path, "w") as f:
-            pass
+        open(path, "w").close()
 
-    with open(path) as f:
-        variable_registry = yaml.safe_load(f)
-        if variable_registry is None:
-            variable_registry = {}
+    variable_registry = _load_variable_registry(path)
 
-        for variable_key in variable_keys:
-            if variable_key not in variable_registry or reset:
-                if custom_dict is not None:
-                    variable_registry.update({variable_key: custom_dict})
-                else:
-                    variable_registry.update(
-                        {
-                            variable_key: {
-                                "name": variable_key,
-                                "bins": "auto",
-                                "range": ("min", "max"),
-                                "label": variable_key,
-                                "log": False,
-                                "legend_location": "best",
-                                "legend_ncols": 1,
-                                "docstring": "",
-                            }
-                        }
-                    )
+    for variable_key in variable_keys:
+        if variable_key not in variable_registry or reset:
+            if custom_dict is not None:
+                variable_registry[variable_key] = copy.deepcopy(custom_dict)
+            else:
+                variable_registry[variable_key] = {
+                    "name": variable_key,
+                    "bins": "auto",
+                    "range": ("min", "max"),
+                    "label": variable_key,
+                    "log": False,
+                    "legend_location": "best",
+                    "legend_ncols": 1,
+                    "docstring": "",
+                }
 
     _save_variable_registry(variable_registry, path=path)
 
@@ -214,8 +229,7 @@ def update_variable_registry(
     """
     _check_if_variable_registry_exists(path)
 
-    with open(path) as f:
-        variable_registry = yaml.safe_load(f)
+    variable_registry = _load_variable_registry(path)
 
     if variable_keys is None:
         variable_keys = list(variable_registry.keys())
@@ -251,8 +265,7 @@ def remove_variable_registry_parameters(
     """
     _check_if_variable_registry_exists(path)
 
-    with open(path) as f:
-        variable_registry = yaml.safe_load(f)
+    variable_registry = _load_variable_registry(path)
 
     if variable_keys is None:
         variable_keys = list(variable_registry.keys())
@@ -314,8 +327,7 @@ def update_variable_registry_binning(
     _check_if_variable_registry_exists(path)
 
     if variable_keys is None:
-        with open(path) as f:
-            variable_registry = yaml.safe_load(f)
+        variable_registry = _load_variable_registry(path)
         variable_keys = list(variable_registry.keys())
 
     for variable_key in variable_keys:

--- a/tests/test_variable_registry.py
+++ b/tests/test_variable_registry.py
@@ -465,3 +465,42 @@ def test_get_variable_from_registry_variable_not_found() -> None:
     )
 
     os.remove(registry_path)
+
+
+def test_update_and_remove_on_empty_registry(tmp_path) -> None:
+    """
+    Regression test: update_variable_registry and remove_variable_registry_parameters
+    on a zero-byte registry file must not raise a TypeError.
+    """
+    registry_path = str(tmp_path / "empty_registry.yaml")
+    # Create a zero-byte file
+    open(registry_path, "w").close()
+
+    # Both functions should be no-ops when variable_keys=None and the file is empty
+    update_variable_registry({"extra": 1}, variable_keys=None, path=registry_path)
+    remove_variable_registry_parameters(
+        ["extra"], variable_keys=None, path=registry_path
+    )
+
+
+def test_create_variable_registry_custom_dict_no_aliasing(tmp_path) -> None:
+    """
+    Regression test: create_variable_registry with custom_dict must produce
+    independent per-variable entries. Mutating one variable's stored parameters
+    must not affect the others.
+    """
+    registry_path = str(tmp_path / "custom_dict_registry.yaml")
+    custom = {"text": "original", "value": 0}
+    create_variable_registry(variable_keys, path=registry_path, custom_dict=custom)
+
+    # Update one variable only
+    update_variable_registry(
+        {"text": "modified"}, ["variable_0"], path=registry_path, overwrite=True
+    )
+
+    # The other variables must retain the original value
+    for key in variable_keys[1:]:
+        registry = get_variable_from_registry(key, path=registry_path)
+        assert registry["text"] == "original", (
+            f"Aliasing bug: {key} was mutated when only variable_0 was updated"
+        )


### PR DESCRIPTION
:robot: Claude Opus

- Extract _load_variable_registry() helper to deduplicate yaml.safe_load boilerplate; returns {} for empty files instead of None
- Fix TypeError crash in update_variable_registry and remove_variable_registry_parameters when called on a zero-byte registry (variable_keys=None over an empty {} is now a clean no-op)
- Fix dict aliasing in create_variable_registry: use copy.deepcopy(custom_dict) per variable key so mutating one entry does not affect others
- Flatten create_variable_registry to read-then-modify-then-save pattern
- Add regression tests for empty-file no-op and custom_dict independence