### PR TITLE
fix: tolerate pre-release boost_histogram versions in import check

### DIFF
--- a/src/plothist/__init__.py
+++ b/src/plothist/__init__.py
@@ -82,8 +82,8 @@ __all__ = [
 ]
 
 
+import re
 from importlib import resources
-from importlib.resources import files
 
 import boost_histogram as bh
 import matplotlib.font_manager as fm
@@ -91,7 +91,7 @@ import matplotlib.pyplot as plt
 
 # Get style file and use it
 
-style_file = files("plothist").joinpath("default_style.mplstyle")
+style_file = resources.files("plothist").joinpath("default_style.mplstyle")
 plt.style.use(style_file)
 
 # Install fonts
@@ -103,7 +103,18 @@ with resources.as_file(resources.files("plothist_utils") / "fonts") as font_path
 
 # Check version of boost_histogram
 
-if tuple(int(part) for part in bh.__version__.split(".")) < (1, 4, 0):
+
+def _parse_version(version_str: str) -> tuple[int, ...]:
+    parts = []
+    for part in version_str.split("."):
+        m = re.match(r"\d+", part)
+        if not m:
+            break
+        parts.append(int(m.group()))
+    return tuple(parts)
+
+
+if _parse_version(bh.__version__) < (1, 4, 0):
     raise ImportError(
         "The version of boost_histogram is lower than 1.4.0. Please update to the latest version to avoid issues (pip install --upgrade boost_histogram).",
     )

--- a/tests/test_boost_histogram_version.py
+++ b/tests/test_boost_histogram_version.py
@@ -14,3 +14,30 @@ def test_import_plothist_version_too_low(monkeypatch: pytest.MonkeyPatch) -> Non
         ImportError, match=r"The version of boost_histogram is lower than 1.4.0"
     ):
         import plothist  # noqa: F401
+
+
+def test_import_plothist_dev_version_above_minimum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a dev version above the minimum imports successfully."""
+    import boost_histogram as bh
+
+    monkeypatch.setattr(bh, "__version__", "1.5.0.dev1")
+    sys.modules.pop("plothist", None)
+    import plothist  # noqa: F401
+
+    sys.modules.pop("plothist", None)
+
+
+def test_import_plothist_rc_version_below_minimum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that an rc version below the minimum still raises ImportError."""
+    import boost_histogram as bh
+
+    monkeypatch.setattr(bh, "__version__", "1.3.9rc1")
+    sys.modules.pop("plothist", None)
+    with pytest.raises(
+        ImportError, match=r"The version of boost_histogram is lower than 1.4.0"
+    ):
+        import plothist  # noqa: F401


### PR DESCRIPTION
:robot: Claude Opus

- Replace redundant `from importlib.resources import files` with `resources.files(...)` using the already-imported `resources` namespace.
- Parse boost_histogram version components tolerantly via re.match so versions like "1.5.0.dev1" or "1.4.0rc1" no longer raise ValueError.
- Add test cases for a dev version above the minimum (imports fine) and an rc version below the minimum (still raises ImportError).